### PR TITLE
Handle exceptions properly in Program.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dotnet-version-cli
 
+[![Build status](https://ci.appveyor.com/api/projects/status/r50rbldhoil6pqk6/branch/master?svg=true)](https://ci.appveyor.com/project/nover/dotnet-version-cli/branch/master)
+
 This repository contains the source code for an [npm version][1] inspired cli tool for the dotnet core SDK 1.0.1 (csproj based).
 
 Once installed it provides a `dotnet version` cli extension which allows you to easily bump `patch`, `minor` and `major` versions on your project.

--- a/src/CsProj/ProjectFileDetector.cs
+++ b/src/CsProj/ProjectFileDetector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Skarp.Version.Cli.CsProj.FileSystem;
@@ -42,11 +43,17 @@ namespace Skarp.Version.Cli.CsProj
             {
                 var files = _fileSystem.List(path);
                 var csProjFiles = files.Where(q => q.EndsWith(".csproj"));
-                if (csProjFiles.Count() > 1)
+                var projFiles = csProjFiles as IList<string> ?? csProjFiles.ToList();
+                if (projFiles.Count == 0)
+                {
+                    throw new OperationCanceledException("No csproj file could be found in path - ensure that you are running `dotnet version` next to the project file");
+                }
+
+                if (projFiles.Count > 1)
                 {
                     var sb = new StringBuilder();
                     sb.AppendLine("Multiple csproj files found - aborting:");
-                    foreach (var project in csProjFiles)
+                    foreach (var project in projFiles)
                     {
                         sb.AppendLine($"\t{project}");
                     }
@@ -54,7 +61,7 @@ namespace Skarp.Version.Cli.CsProj
                     throw new OperationCanceledException(sb.ToString());
                 }
 
-                csProjFile = csProjFiles.Single();
+                csProjFile = projFiles.Single();
             }
             ResolvedCsProjFile = csProjFile;
             

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -43,23 +43,26 @@ namespace Skarp.Version.Cli
             commandLineApplication.Execute(args);
         }
 
-        private static VersionBump GetVersionBumpFromRemainingArgs(List<string> remainingArguments)
+        internal static VersionBump GetVersionBumpFromRemainingArgs(List<string> remainingArguments)
         {
-            var regex = new Regex(@"(major)|(minor)|(patch)", RegexOptions.Compiled);
+            if (remainingArguments == null || !remainingArguments.Any())
+            {
+                var msgEx = "No version bump specified, please specify one of:\n\tmajor | minor | patch";
+                // ReSharper disable once NotResolvedInText
+                throw new ArgumentException(msgEx, "versionBump");
+            }
+
+            VersionBump bump = VersionBump.Patch;
             foreach (var arg in remainingArguments)
             {
-                if (!regex.IsMatch(arg)) continue;
-                VersionBump bump;
-                if (Enum.TryParse(arg, true, out bump)) return bump;
+                if (Enum.TryParse(arg, true, out bump)) break;
 
-                Console.WriteLine($"Invalid version bump specified: {arg}");
-                Environment.Exit(1);
-                return bump;
+                var msg = $"Invalid version bump specified: {arg}";
+                // ReSharper disable once NotResolvedInText
+                throw new ArgumentException(msg, "versionBump");
             }
-            Console.WriteLine("No version bump specified, please specify one of:\n\tmajor | minor | patch");
-            Environment.Exit(1);
 
-            return VersionBump.Patch;
+            return bump;
         }
 
         private static void SetUpLogging()

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.CommandLineUtils;
 using Skarp.Version.Cli.CsProj;
@@ -31,12 +32,12 @@ namespace Skarp.Version.Cli
             {
                 if (commandLineApplication.RemainingArguments.Count == 0)
                 {
-                    DumpVersion();
+                    _cli.DumpVersion();
                     return 0;
                 }
 
                 var versionBump = GetVersionBumpFromRemainingArgs(commandLineApplication.RemainingArguments);
-                PatchVersion(versionBump);
+                _cli.Execute(versionBump);
 
                 return 0;
             });
@@ -78,21 +79,6 @@ namespace Skarp.Version.Cli
                 ),
                 new ProjectFileParser(),
                 new ProjectFileVersionPatcher()
-            );
-        }
-
-        private static void DumpVersion(string path = "")
-        {
-            _cli.DumpVersion(path);
-            Environment.Exit(0);
-        }
-
-        private static void PatchVersion(VersionBump bump, string commitMsg = "", string path = "")
-        {
-            _cli.Execute(
-                bump,
-                commitMsg,
-                path
             );
         }
     }

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("dotnet-version-test")]

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Drawing;
 using Skarp.Version.Cli.CsProj;
 using Skarp.Version.Cli.Vcs;
+using Console = Colorful.Console;
 
 namespace Skarp.Version.Cli
 {
@@ -28,13 +30,13 @@ namespace Skarp.Version.Cli
         {
             if (!_vcsTool.IsVcsToolPresent())
             {
-                Console.WriteLine($"Unable to find the vcs tool {_vcsTool.ToolName()} in your path");
+                Console.WriteLine($"ERR Unable to find the vcs tool {_vcsTool.ToolName()} in your path", Color.Red);
                 Environment.Exit(1);
             }
 
             if (!_vcsTool.IsRepositoryClean())
             {
-                Console.WriteLine($"You currently have uncomitted changes in your repository, please commit these and try again");
+                Console.WriteLine($"WARN You currently have uncomitted changes in your repository, please commit these and try again", Color.Chocolate);
                 Environment.Exit(1);
             }
 
@@ -58,10 +60,7 @@ namespace Skarp.Version.Cli
             _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{newVersion}");
             _vcsTool.Tag($"v{newVersion}");
 
-            Console.WriteLine(
-                "Bumped {0} to version {1}",
-                _fileDetector.ResolvedCsProjFile,
-                newVersion);
+            Console.WriteLine($"Bumped {_fileDetector.ResolvedCsProjFile} to version {newVersion}", Color.DodgerBlue);
         }
 
         public void DumpVersion(string csProjFilePath = "")

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <RootNamespace>Skarp.Version.Cli</RootNamespace>
     <Version>0.1.2</Version>
-
     <Title>dotnet-version-cli</Title>
     <Authors>nover</Authors>
     <Description>A dotnet core CliTool for changing your csproj Version and automatically comitting and tagging - npm version style.</Description>
@@ -18,6 +17,7 @@
     <Company>SKARP ApS</Company>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Colorful.Console" Version="1.0.7" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.1.2" />
   </ItemGroup>

--- a/test/CsProj/ProjectFileDetectorTest.cs
+++ b/test/CsProj/ProjectFileDetectorTest.cs
@@ -72,6 +72,27 @@ namespace Skarp.Version.Cli.Test.CsProj
         }
 
         [Fact]
+        public void Aborts_when_no_csproj_file()
+        {
+            const string rootPath = "/unit-test";
+
+            var fakeFileSystem = A.Fake<IFileSystemProvider>(opts => opts.Strict());
+            A.CallTo(() => fakeFileSystem.List(A<string>._)).Returns(
+                new List<string>{
+                    $"{rootPath}/Test.cs",
+                }
+            );
+            A.CallTo(() =>
+                    fakeFileSystem.IsCsProjectFile(
+                        A<string>.That.Matches(str => str == $"{rootPath}")))
+                .Returns(false);
+
+
+            var detect = new ProjectFileDetector(fakeFileSystem);
+            Assert.Throws<OperationCanceledException>(() => detect.FindAndLoadCsProj(rootPath));
+        }
+
+        [Fact]
         public void CanDetectCsProjFileWithGivenBootstrapCsProj()
         {
             const string rootPath = "/unit-test";

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
+using Xunit;
+
+namespace Skarp.Version.Cli.Test
+{
+    public class ProgramTest
+    {
+
+        [Theory]
+        [InlineData("major", VersionBump.Major)]
+        [InlineData("minor", VersionBump.Minor)]
+        [InlineData("patch", VersionBump.Patch)]
+        public void GetVersionBumpFromRemaingArgsWork(string strVersionBump, VersionBump expectedBump)
+        {
+            var theBump = Program.GetVersionBumpFromRemainingArgs(new List<string>() {strVersionBump});
+            Assert.Equal(expectedBump, theBump);
+        }
+
+        [Fact]
+        public void Get_version_bump_throws_on_missing_value()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>()));
+            Assert.Equal($"No version bump specified, please specify one of:\n\tmajor | minor | patch{Environment.NewLine}Parameter name: versionBump", ex.Message);
+            Assert.Equal("versionBump", ex.ParamName);
+        }
+
+        [Fact]
+        public void Get_version_bump_throws_on_invalid_value()
+        {
+            const string invalidVersion = "invalid-version";
+
+            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>{invalidVersion}));
+            Assert.Equal($"Invalid version bump specified: {invalidVersion}{Environment.NewLine}Parameter name: versionBump", ex.Message);
+            Assert.Equal("versionBump", ex.ParamName);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #3 

It includes a number of fixes

- Make parts of Program.cs testable and clean up the code in that file
-  Add Colorful.Console as dep
- Fixes bug in ProjectFileDetector when no cs proj files are detected
- Fixes Program.cs to not crash on exceptions in VersionCli but rather write the messages in a nice way
- Add appveyor build badge to readme