### PR TITLE
Fix bug in version part validator

### DIFF
--- a/src/SemVer.cs
+++ b/src/SemVer.cs
@@ -5,7 +5,7 @@ namespace Skarp.Version.Cli
 {
     public class SemVer
     {
-        private static readonly Regex VersionPartRegex = new Regex(@"^\d$", RegexOptions.Compiled);
+        private static readonly Regex VersionPartRegex = new Regex(@"^\d+$", RegexOptions.Compiled);
 
         /// <summary>
         /// Bump the currently parsed version information with the specified <paramref name="bump"/>

--- a/test/SemVerTest.cs
+++ b/test/SemVerTest.cs
@@ -8,7 +8,11 @@ namespace Skarp.Version.Cli.Test
 
         [Theory]
         [InlineData("1.0.0", 1, 0, 0)]
+        [InlineData("0.10.0", 0, 10, 0)]
+        [InlineData("1.12.99", 1, 12, 99)]
+        [InlineData("4.99.43245", 4, 99, 43245)]
         [InlineData("4.1.3", 4, 1, 3)]
+        [InlineData("42.4.554", 42, 4, 554)]
         [InlineData("2.1", 2, 1, 0)]
         [InlineData("2", 2, 0, 0)]
         [InlineData("4.1.3.6.7.8.9", 4, 1, 3)] // too many version numbers


### PR DESCRIPTION
The version part validator only allowed single number version parts
which is not sufficient as bumping beyond version 10 in any part
would result in ERR invalid version.

Added additional tests to show problem and fix