### PR TITLE
Add support for JSON output on success

### DIFF
--- a/src/OutputFormat.cs
+++ b/src/OutputFormat.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skarp.Version.Cli
+{
+    public enum OutputFormat
+    {
+        /// <summary>
+        /// Regular text output
+        /// </summary>
+        Text,
+
+        /// <summary>
+        /// json output
+        /// </summary>
+        Json
+    }
+}

--- a/src/ProductInfo.cs
+++ b/src/ProductInfo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Skarp.Version.Cli
+{
+    public static class ProductInfo
+    {
+        /// <summary>
+        /// The name of the product
+        /// </summary>
+        public static string Name = "dotnet-version-cli";
+
+        /// <summary>
+        /// The version of the running product
+        /// </summary>
+        public static string Version = Assembly.GetEntryAssembly().GetName().Version.ToString();
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -14,7 +14,6 @@ namespace Skarp.Version.Cli
 
         static void Main(string[] args)
         {
-            Console.WriteLine("dotnet-version-cli");
             SetUpLogging();
             SetUpDependencies();
 
@@ -27,17 +26,32 @@ namespace Skarp.Version.Cli
 
 
             commandLineApplication.HelpOption("-? | -h | --help");
+            var outputFormatOption = commandLineApplication.Option(
+                "-o | --output-format <format>", "Change output format, allowed values: json, text - default value is text",
+                CommandOptionType.SingleValue);
+
             commandLineApplication.OnExecute(() =>
             {
                 try
                 {
+                    var outputFormat = OutputFormat.Text;
+                    if (outputFormatOption.HasValue())
+                    {
+                        outputFormat = (OutputFormat) Enum.Parse(typeof(OutputFormat), outputFormatOption.Value(), true);
+                    }
+
+                    if (outputFormat == OutputFormat.Text)
+                    {
+                        Console.WriteLine("dotnet-version-cli");
+                    }
+
                     if (commandLineApplication.RemainingArguments.Count == 0)
                     {
                         _cli.DumpVersion(new VersionCliArgs());
                         return 0;
                     }
 
-                    var cliArgs = GetVersionBumpFromRemainingArgs(commandLineApplication.RemainingArguments);
+                    var cliArgs = GetVersionBumpFromRemainingArgs(commandLineApplication.RemainingArguments, outputFormat);
                     _cli.Execute(cliArgs);
 
                     return 0;
@@ -63,7 +77,7 @@ namespace Skarp.Version.Cli
             commandLineApplication.Execute(args);
         }
 
-        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(List<string> remainingArguments)
+        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(List<string> remainingArguments, OutputFormat outputFormat)
         {
             if (remainingArguments == null || !remainingArguments.Any())
             {
@@ -72,7 +86,7 @@ namespace Skarp.Version.Cli
                 throw new ArgumentException(msgEx, "versionBump");
             }
 
-            var args = new VersionCliArgs();
+            var args = new VersionCliArgs { OutputFormat = outputFormat };
             var bump = VersionBump.Patch;
 
             foreach (var arg in remainingArguments)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.CommandLineUtils;
 using Skarp.Version.Cli.CsProj;
 using Skarp.Version.Cli.CsProj.FileSystem;
@@ -42,7 +43,7 @@ namespace Skarp.Version.Cli
 
                     if (outputFormat == OutputFormat.Text)
                     {
-                        Console.WriteLine("dotnet-version-cli");
+                        Console.WriteLine($"{ProductInfo.Name} version {ProductInfo.Version}");
                     }
 
                     if (commandLineApplication.RemainingArguments.Count == 0)

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -64,10 +64,15 @@ namespace Skarp.Version.Cli
             {
                 var theOutput = new
                 {
+                    Product = new
+                    {
+                        Name = ProductInfo.Name,
+                        Version = ProductInfo.Version
+                    },
                     OldVersion = _fileParser.Version,
                     NewVersion = newVersion,
                     ProjectFile = _fileDetector.ResolvedCsProjFile,
-                    VersionStrategy = args.VersionBump.ToString()
+                    VersionStrategy = args.VersionBump.ToString().ToLowerInvariant()
                 };
 
                 Console.WriteLine(

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -1,4 +1,6 @@
 using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Skarp.Version.Cli.CsProj;
 using Skarp.Version.Cli.Vcs;
 
@@ -58,7 +60,27 @@ namespace Skarp.Version.Cli
             _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{newVersion}");
             _vcsTool.Tag($"v{newVersion}");
 
-            Console.WriteLine($"Bumped {_fileDetector.ResolvedCsProjFile} to version {newVersion}");
+            if (args.OutputFormat == OutputFormat.Json)
+            {
+                var theOutput = new
+                {
+                    OldVersion = _fileParser.Version,
+                    NewVersion = newVersion,
+                    ProjectFile = _fileDetector.ResolvedCsProjFile,
+                    VersionStrategy = args.VersionBump.ToString()
+                };
+
+                Console.WriteLine(
+                    JsonConvert.SerializeObject(
+                        theOutput, new JsonSerializerSettings
+                        {
+                            ContractResolver = new CamelCasePropertyNamesContractResolver()
+                        }));
+            }
+            else
+            {
+                Console.WriteLine($"Bumped {_fileDetector.ResolvedCsProjFile} to version {newVersion}");
+            }
         }
 
         public void DumpVersion(VersionCliArgs args)

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -5,6 +5,9 @@
         public VersionBump VersionBump { get; set; }
 
         public string SpecificVersionToApply { get; set; }
+
         public string CsProjFilePath { get; set; }
+
+        public OutputFormat OutputFormat { get; set; }
     }
 }

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.3.1" />
   </ItemGroup>
 </Project>

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using FakeItEasy;
+using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.VisualStudio.TestPlatform.TestHost;
 using Xunit;
 
@@ -15,8 +17,8 @@ namespace Skarp.Version.Cli.Test
         [InlineData("patch", VersionBump.Patch)]
         [InlineData("1.0.1", VersionBump.Specific)]
         public void GetVersionBumpFromRemaingArgsWork(string strVersionBump, VersionBump expectedBump)
-        {
-            var args = Program.GetVersionBumpFromRemainingArgs(new List<string>() {strVersionBump});
+        { 
+            var args = Program.GetVersionBumpFromRemainingArgs(new List<string>() {strVersionBump}, OutputFormat.Text);
             Assert.Equal(expectedBump, args.VersionBump);
             if (expectedBump == VersionBump.Specific)
             {
@@ -27,7 +29,7 @@ namespace Skarp.Version.Cli.Test
         [Fact]
         public void Get_version_bump_throws_on_missing_value()
         {
-            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>()));
+            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>(), OutputFormat.Text));
             Assert.Equal($"No version bump specified, please specify one of:\n\tmajor | minor | patch | <specific version>{Environment.NewLine}Parameter name: versionBump", ex.Message);
             Assert.Equal("versionBump", ex.ParamName);
         }
@@ -37,7 +39,7 @@ namespace Skarp.Version.Cli.Test
         {
             const string invalidVersion = "invalid-version";
 
-            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>{invalidVersion}));
+            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>{invalidVersion}, OutputFormat.Text));
             Assert.Equal($"Malformed version part: {invalidVersion}{Environment.NewLine}Parameter name: versionString", ex.Message);
             Assert.Equal("versionString", ex.ParamName);
         }


### PR DESCRIPTION
Upon successful termination of the program (the version update went well) allow the caller to specify whether to output "text" or "json". This allows better programmatic use of the CLI tool as parsing json is way more fun than parsing free text on standard out.