### PR TITLE
Add json output support when dumping project versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Effectively this means that issuing a `patch` command will
 
 Similarly for `minor` and `major`, but changing different parts of the version number.
 
+To control the output format the `--output-format` switch can be used - currently supported values are `json` and `text`. **Please beware** that output is only reformatted for success-cases, so if something is wrong you will get a non 0 exit code and text output!
+Changing output format works for both "version bumping" and the "show version" operations of the cli.
+
 ## Installing the cli tool
 
 To install the cli tool add it to the `csproj` file of your library / application:
@@ -41,6 +44,15 @@ dotnet-version-cli
 Project version is:
         1.3.0
 ```
+
+Using json output will produce
+
+```bash
+$ dotnet version --output-format=json
+{"product":{"name":"dotnet-version-cli","version":"0.4.0.0"},"currentVersion":"1.3.0","projectFile":"C:\\your\\stuff\\project.csproj"}
+```
+
+The `product` bit is information about the CLI tool itself.
 
 ## Standard workflow
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -48,7 +48,10 @@ namespace Skarp.Version.Cli
 
                     if (commandLineApplication.RemainingArguments.Count == 0)
                     {
-                        _cli.DumpVersion(new VersionCliArgs());
+                        _cli.DumpVersion(new VersionCliArgs
+                        {
+                            OutputFormat = outputFormat
+                        });
                         return 0;
                     }
 

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -75,12 +75,7 @@ namespace Skarp.Version.Cli
                     VersionStrategy = args.VersionBump.ToString().ToLowerInvariant()
                 };
 
-                Console.WriteLine(
-                    JsonConvert.SerializeObject(
-                        theOutput, new JsonSerializerSettings
-                        {
-                            ContractResolver = new CamelCasePropertyNamesContractResolver()
-                        }));
+                WriteJsonToStdout(theOutput);
             }
             else
             {
@@ -93,7 +88,35 @@ namespace Skarp.Version.Cli
             var csProjXml = _fileDetector.FindAndLoadCsProj(args.CsProjFilePath);
             _fileParser.Load(csProjXml);
 
-            Console.WriteLine("Project version is: {0}\t{1}", Environment.NewLine, _fileParser.Version);
+            if (args.OutputFormat == OutputFormat.Json)
+            {
+                var theOutput = new
+                {
+                    Product = new
+                    {
+                        Name = ProductInfo.Name,
+                        Version = ProductInfo.Version
+                    },
+                    CurrentVersion = _fileParser.Version,
+                    ProjectFile = _fileDetector.ResolvedCsProjFile,
+                };
+                WriteJsonToStdout(theOutput);
+            }
+            else
+            {
+                Console.WriteLine("Project version is: {0}\t{1}", Environment.NewLine, _fileParser.Version);
+            }
         }
+
+        private static void WriteJsonToStdout(object theOutput)
+        {
+            Console.WriteLine(
+                JsonConvert.SerializeObject(
+                    theOutput, new JsonSerializerSettings
+                    {
+                        ContractResolver = new CamelCasePropertyNamesContractResolver()
+                    }));
+        }
+
     }
 }

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>


### PR DESCRIPTION
So when invoking the cli as `dotnet version` it now supports writing the output data as JSON.