### PR TITLE
Add netcoreapp 1.1 and 2.0 as targets

### DIFF
--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -6,8 +6,8 @@
     <Version>0.4.1</Version>
     <Title>dotnet-version-cli</Title>
     <Authors>nover</Authors>
-    <Description>A dotnet core CliTool for changing your csproj Version and automatically comitting and tagging - npm version style.</Description>
-    <PackageTags>dotnet core;version; npm version;version patch;</PackageTags>
+    <Description>A dotnet core cli tool for changing your csproj version and automatically comitting and tagging - npm version style.</Description>
+    <PackageTags>core;version;npm version;version patch;</PackageTags>
     <PackageProjectUrl>https://github.com/skarpdev/dotnet-version-cli/</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/skarpdev/dotnet-version-cli/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>Skarp.Version.Cli</RootNamespace>
     <Version>0.4.1</Version>
     <Title>dotnet-version-cli</Title>


### PR DESCRIPTION
To allow more users to utilize the cli-tool. I.e Ubuntu 17.04 only supports dotnet core 2.0 so users on that platform can currently not install and use the tool.