### PR TITLE
Feature/bump version without commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Similarly for `minor` and `major`, but changing different parts of the version n
 To control the output format the `--output-format` switch can be used - currently supported values are `json` and `text`. **Please beware** that output is only reformatted for success-cases, so if something is wrong you will get a non 0 exit code and text output!
 Changing output format works for both "version bumping" and the "show version" operations of the cli.
 
+The commit and tag can be disabled via the `--skip-vcs` option.
+
 ## Installing the cli tool
 
 To install the cli tool add it to the `csproj` file of your library / application:

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -30,6 +30,10 @@ namespace Skarp.Version.Cli
             var outputFormatOption = commandLineApplication.Option(
                 "-o | --output-format <format>", "Change output format, allowed values: json, text - default value is text",
                 CommandOptionType.SingleValue);
+            
+            var skipVcsOption = commandLineApplication.Option(
+                "-s | --skip-vcs", "Disable version control system changes - default is to tag and commit new version",
+                CommandOptionType.NoValue);
 
             commandLineApplication.OnExecute(() =>
             {
@@ -46,6 +50,8 @@ namespace Skarp.Version.Cli
                         Console.WriteLine($"{ProductInfo.Name} version {ProductInfo.Version}");
                     }
 
+                    var doVcs = !skipVcsOption.HasValue();
+
                     if (commandLineApplication.RemainingArguments.Count == 0)
                     {
                         _cli.DumpVersion(new VersionCliArgs
@@ -55,7 +61,7 @@ namespace Skarp.Version.Cli
                         return 0;
                     }
 
-                    var cliArgs = GetVersionBumpFromRemainingArgs(commandLineApplication.RemainingArguments, outputFormat);
+                    var cliArgs = GetVersionBumpFromRemainingArgs(commandLineApplication.RemainingArguments, outputFormat, doVcs);
                     _cli.Execute(cliArgs);
 
                     return 0;
@@ -81,7 +87,7 @@ namespace Skarp.Version.Cli
             commandLineApplication.Execute(args);
         }
 
-        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(List<string> remainingArguments, OutputFormat outputFormat)
+        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(List<string> remainingArguments, OutputFormat outputFormat, bool doVcs)
         {
             if (remainingArguments == null || !remainingArguments.Any())
             {
@@ -90,7 +96,7 @@ namespace Skarp.Version.Cli
                 throw new ArgumentException(msgEx, "versionBump");
             }
 
-            var args = new VersionCliArgs { OutputFormat = outputFormat };
+            var args = new VersionCliArgs { OutputFormat = outputFormat, DoVcs = doVcs };
             var bump = VersionBump.Patch;
 
             foreach (var arg in remainingArguments)

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -28,13 +28,13 @@ namespace Skarp.Version.Cli
 
         public void Execute(VersionCliArgs args)
         {
-            if (!_vcsTool.IsVcsToolPresent())
+            if (args.DoVcs && !_vcsTool.IsVcsToolPresent())
             {
                 throw new OperationCanceledException(
                     $"Unable to find the vcs tool {_vcsTool.ToolName()} in your path");
             }
 
-            if (!_vcsTool.IsRepositoryClean())
+            if (args.DoVcs && !_vcsTool.IsRepositoryClean())
             {
                 throw new OperationCanceledException(
                     "You currently have uncomitted changes in your repository, please commit these and try again");
@@ -56,9 +56,13 @@ namespace Skarp.Version.Cli
                 _fileDetector.ResolvedCsProjFile
             );
 
-            // Run git commands
-            _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{newVersion}");
-            _vcsTool.Tag($"v{newVersion}");
+            if (args.DoVcs)
+            {
+                // Run git commands
+                _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{newVersion}");
+                _vcsTool.Tag($"v{newVersion}");                
+            }
+            
 
             if (args.OutputFormat == OutputFormat.Json)
             {

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -9,5 +9,11 @@
         public string CsProjFilePath { get; set; }
 
         public OutputFormat OutputFormat { get; set; }
+        
+        /// <summary>
+        /// Whether or not to do version control changes like
+        /// commit and tag.
+        /// </summary>
+        public bool DoVcs { get; set; }
     }
 }

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -18,7 +18,7 @@ namespace Skarp.Version.Cli.Test
         [InlineData("1.0.1", VersionBump.Specific)]
         public void GetVersionBumpFromRemaingArgsWork(string strVersionBump, VersionBump expectedBump)
         { 
-            var args = Program.GetVersionBumpFromRemainingArgs(new List<string>() {strVersionBump}, OutputFormat.Text);
+            var args = Program.GetVersionBumpFromRemainingArgs(new List<string>() {strVersionBump}, OutputFormat.Text, true);
             Assert.Equal(expectedBump, args.VersionBump);
             if (expectedBump == VersionBump.Specific)
             {
@@ -29,7 +29,7 @@ namespace Skarp.Version.Cli.Test
         [Fact]
         public void Get_version_bump_throws_on_missing_value()
         {
-            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>(), OutputFormat.Text));
+            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>(), OutputFormat.Text, true));
             Assert.Equal($"No version bump specified, please specify one of:\n\tmajor | minor | patch | <specific version>{Environment.NewLine}Parameter name: versionBump", ex.Message);
             Assert.Equal("versionBump", ex.ParamName);
         }
@@ -39,7 +39,7 @@ namespace Skarp.Version.Cli.Test
         {
             const string invalidVersion = "invalid-version";
 
-            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>{invalidVersion}, OutputFormat.Text));
+            var ex = Assert.Throws<ArgumentException>(() => Program.GetVersionBumpFromRemainingArgs(new List<string>{invalidVersion}, OutputFormat.Text, true));
             Assert.Equal($"Malformed version part: {invalidVersion}{Environment.NewLine}Parameter name: versionString", ex.Message);
             Assert.Equal("versionString", ex.ParamName);
         }


### PR DESCRIPTION
Allows users to disable the commit and tag operation using the `--skip-vcs` command line arg.

Closes #18 