### PR TITLE
Update dotnet version targeting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{build}'
+image: Visual Studio 2019
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-version</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/test/CsProj/ProjectFileParserTest.cs
+++ b/test/CsProj/ProjectFileParserTest.cs
@@ -45,7 +45,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                 parser.Load(csProjXml)
             );
             
-            Assert.Equal($"Provided csproj file does not contain a <Version>{Environment.NewLine}Parameter name: version", ex.Message);
+            Assert.Contains($"Provided csproj file does not contain a <Version>", ex.Message);
             Assert.Equal("version", ex.ParamName);
         }
 
@@ -64,7 +64,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                 parser.Load(csProjXml)
             );
             
-            Assert.Equal($"The provided csproj file seems malformed - no <Project> in the root{Environment.NewLine}Parameter name: project", ex.Message);
+            Assert.Contains($"The provided csproj file seems malformed - no <Project> in the root", ex.Message);
             Assert.Equal("project", ex.ParamName);
         }
     }

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -32,8 +32,8 @@ namespace Skarp.Version.Cli.Test
             var ex = Assert.Throws<ArgumentException>(() =>
                 Program.GetVersionBumpFromRemainingArgs(new List<string>(), OutputFormat.Text, true, true,
                     string.Empty));
-            Assert.Equal(
-                $"No version bump specified, please specify one of:\n\tmajor | minor | patch | <specific version>{Environment.NewLine}Parameter name: versionBump",
+            Assert.Contains(
+                $"No version bump specified, please specify one of:\n\tmajor | minor | patch | <specific version>",
                 ex.Message);
             Assert.Equal("versionBump", ex.ParamName);
         }
@@ -46,7 +46,7 @@ namespace Skarp.Version.Cli.Test
             var ex = Assert.Throws<ArgumentException>(() =>
                 Program.GetVersionBumpFromRemainingArgs(new List<string> {invalidVersion}, OutputFormat.Text, true,
                     true, string.Empty));
-            Assert.Equal($"Malformed version part: {invalidVersion}{Environment.NewLine}Parameter name: versionString",
+            Assert.Contains($"Malformed version part: {invalidVersion}",
                 ex.Message);
             Assert.Equal("versionString", ex.ParamName);
         }

--- a/test/SemVerTest.cs
+++ b/test/SemVerTest.cs
@@ -32,7 +32,7 @@ namespace Skarp.Version.Cli.Test
         {
             var ex = Assert.Throws<ArgumentException>(() => SemVer.FromString(version));
             Assert.Equal("versionString", ex.ParamName);
-            Assert.Equal(ex.Message, $"Malformed version part: {version}{Environment.NewLine}Parameter name: versionString");
+            Assert.Contains($"Malformed version part: {version}", ex.Message);
         }
 
         [Theory]

--- a/test/dotnet-version-test.csproj
+++ b/test/dotnet-version-test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Skarp.Version.Cli.Test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Make it multi targeted so that it will work in docker images that have
the following sdk installed

- 2.1
- 2.2
- 3.0
- 3.1

Closes #30 