### PR TITLE
Add support for handling pre-releases

### DIFF
--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -8,6 +8,8 @@ namespace Skarp.Version.Cli.CsProj
     public class ProjectFileParser
     {
         public virtual string Version { get; private set; }
+        
+        public virtual string PackageVersion { get; private set; }
 
         public virtual void Load(string xmlDocument)
         {
@@ -31,12 +33,14 @@ namespace Skarp.Version.Cli.CsProj
                 where prop.Name == "Version"
                 select prop
             ).FirstOrDefault();
-
-            if(xVersion == null)
-            {
-                throw new ArgumentException("Provided csproj file does not contain a <Version>", paramName: "version");
-            }
-            Version = xVersion.Value;            
+            Version = xVersion?.Value ?? "0.0.0";
+            
+            var xPackageVersion = (
+                from prop in propertyGroup.Elements()
+                where prop.Name == "PackageVersion"
+                select prop
+            ).FirstOrDefault();
+            PackageVersion = xPackageVersion?.Value ?? Version;
         }
     }
 }

--- a/src/CsProj/ProjectFileVersionPatcher.cs
+++ b/src/CsProj/ProjectFileVersionPatcher.cs
@@ -1,22 +1,91 @@
+using System;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace Skarp.Version.Cli.CsProj
 {
     public class ProjectFileVersionPatcher
     {
+        private XDocument _doc;
+
+        public virtual void Load(string xmlDocument)
+        {
+            _doc = XDocument.Parse(xmlDocument);
+        }
+
         /// <summary>
         /// Replace the existing version number in the csproj xml with the new version
         /// </summary>
-        /// <param name="xml">The csproj xml loaded from disk</param>
         /// <param name="oldVersion">The old version number present in the xml</param>
         /// <param name="newVersion">The new version number to persist in the csproj file</param>
         /// <returns></returns>
-        public virtual string Patch(string xml, string oldVersion, string newVersion)
+        public virtual void PatchVersionField(string oldVersion, string newVersion)
         {
-            return xml.Replace(
-                $"<Version>{oldVersion}</Version>", 
-                $"<Version>{newVersion}</Version>"
-            );
+            var elementName = "Version";
+            PatchGenericField(elementName, oldVersion, newVersion);
+        }
+
+        /// <summary>
+        /// Replace the existing PackageVersion number in the csproj xml file
+        /// </summary>
+        /// <param name="oldVersion">Old version to replace</param>
+        /// <param name="newVersion">New version to insert</param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException"></exception>
+        public virtual void PatchPackageVersionField(string oldVersion, string newVersion)
+        {
+            var elementName = "PackageVersion";
+            PatchGenericField(elementName, oldVersion, newVersion);
+        }
+
+        /// <summary>
+        /// Helper method for patching up a generic XML field in the loaded XML
+        /// </summary>
+        /// <param name="elementName">The name to find and update or add it to the tree</param>
+        /// <param name="oldVal">Old value</param>
+        /// <param name="newVal">New value</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        private void PatchGenericField(string elementName, string oldVal, string newVal)
+        {
+            if (_doc == null)
+            {
+                throw new InvalidOperationException("Please call Load(string xml) before invoking patch operations");
+            }
+
+            // If the element is not present, add it to the XML document (csproj file
+            if (!ContainsElement(elementName))
+            {
+                AddMissingElementToCsProj(elementName, oldVal);
+            }
+
+            var elm = _doc.Descendants(elementName).First();
+            elm.Value = newVal;
+        }
+
+        private bool ContainsElement(string elementName)
+        {
+            var nodes = _doc.Descendants(elementName);
+            return nodes.Any();
+        }
+        
+        private void AddMissingElementToCsProj(string elementName, string value)
+        {
+            // try to locate the PropertyGroup where the element belongs 
+            var node = _doc.Descendants("TargetFramework").FirstOrDefault();
+            if (node == null)
+            {
+                node = _doc.Descendants("TargetFrameworks").FirstOrDefault();
+
+                if (node == null)
+                {
+                    throw new ArgumentException(
+                        "Given XML does not contain PackageVersion and cannot locate PropertyGroup to add it to - is this a valid csproj?");
+                }
+            }
+
+            var propertyGroup = node.Parent;
+            propertyGroup.Add(new XElement(elementName, value));
         }
 
         /// <summary>
@@ -24,9 +93,18 @@ namespace Skarp.Version.Cli.CsProj
         /// </summary>
         /// <param name="xml">The csproj xml content</param>
         /// <param name="filePath">The path of the csproj to write to</param>
-        public virtual void Flush(string xml, string filePath)
+        public virtual void Flush(string filePath)
         {
-            File.WriteAllText(filePath, xml);
+            File.WriteAllText(filePath, _doc.ToString());
+        }
+
+        /// <summary>
+        /// Get the underlying csproj XML back from the patcher
+        /// </summary>
+        /// <returns></returns>
+        public virtual string ToXml()
+        {
+            return _doc.ToString();
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -44,6 +44,11 @@ namespace Skarp.Version.Cli
                 "-f | --project-file <path/to/csproj>",
                 "The project file to work on. Defaults to auto-locating in current directory",
                 CommandOptionType.SingleValue);
+            
+            var buildMetaOption = commandLineApplication.Option(
+                "-b | --build-meta <the-build-meta>",
+                "Additional build metadata to add to a `premajor`, `preminor` or `prepatch` version bump",
+                CommandOptionType.SingleValue);
 
             commandLineApplication.OnExecute(() =>
             {
@@ -79,7 +84,8 @@ namespace Skarp.Version.Cli
                         outputFormat,
                         doVcs,
                         dryRunEnabled,
-                        csProjectFileOption.Value()
+                        csProjectFileOption.Value(),
+                        buildMetaOption.Value()
                     );
                     _cli.Execute(cliArgs);
 
@@ -110,22 +116,29 @@ namespace Skarp.Version.Cli
             commandLineApplication.Execute(args);
         }
 
-        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(
-            List<string> remainingArguments,
+        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(List<string> remainingArguments,
             OutputFormat outputFormat,
             bool doVcs,
             bool dryRunEnabled,
-            string userSpecifiedCsProjFilePath)
+            string userSpecifiedCsProjFilePath, 
+            string userSpecifiedBuildMeta
+        )
         {
             if (remainingArguments == null || !remainingArguments.Any())
             {
                 var msgEx =
-                    "No version bump specified, please specify one of:\n\tmajor | minor | patch | <specific version>";
+                    "No version bump specified, please specify one of:\n\tmajor | minor | patch | premajor | preminor | prepatch | <specific version>";
                 // ReSharper disable once NotResolvedInText
                 throw new ArgumentException(msgEx, "versionBump");
             }
 
-            var args = new VersionCliArgs {OutputFormat = outputFormat, DoVcs = doVcs, DryRun = dryRunEnabled};
+            var args = new VersionCliArgs
+            {
+                OutputFormat = outputFormat,
+                DoVcs = doVcs,
+                DryRun = dryRunEnabled,
+                BuildMeta =  userSpecifiedBuildMeta,
+            };
             var bump = VersionBump.Patch;
 
             foreach (var arg in remainingArguments)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -133,7 +133,7 @@ namespace Skarp.Version.Cli
                 if (Enum.TryParse(arg, true, out bump)) break;
 
                 var ver = SemVer.FromString(arg);
-                args.SpecificVersionToApply = ver.ToVersionString();
+                args.SpecificVersionToApply = ver.ToSemVerVersionString();
                 bump = VersionBump.Specific;
             }
 

--- a/src/SemVer.cs
+++ b/src/SemVer.cs
@@ -1,37 +1,111 @@
 using System;
+using System.Security.Principal;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Skarp.Version.Cli
 {
     public class SemVer
     {
-        private static readonly Regex VersionPartRegex = new Regex(@"^\d+$", RegexOptions.Compiled);
+        // this lovely little regex comes from the SemVer spec:
+        // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        private static readonly Regex VersionPartRegex = new Regex(
+            @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+            RegexOptions.Compiled,
+            TimeSpan.FromSeconds(2)
+        );
 
         /// <summary>
         /// Bump the currently parsed version information with the specified <paramref name="bump"/>
         /// </summary>
         /// <param name="bump">The bump to apply to the version</param>
         /// <param name="specificVersionToApply">The specific version to apply if bump is Specific</param>
-        public void Bump(VersionBump bump, string specificVersionToApply = "")
+        /// <param name="buildMeta"></param>
+        public void Bump(VersionBump bump, string specificVersionToApply = "", string buildMeta = "")
         {
-            switch(bump)
+            BuildMeta = buildMeta;
+            switch (bump)
             {
                 case VersionBump.Major:
+                {
+                    if (!IsPreRelease)
+                    {
+                        Major += 1;
+                        Minor = 0;
+                        Patch = 0;
+                    }
+                    else
+                    {
+                        PreRelease = string.Empty;
+                        BuildMeta = string.Empty;
+                    }
+
+                    break;
+                }
+                case VersionBump.PreMajor:
                 {
                     Major += 1;
                     Minor = 0;
                     Patch = 0;
+                    PreRelease = "0";
                     break;
-                }    
+                }
                 case VersionBump.Minor:
+                {
+                    if (!IsPreRelease)
+                    {
+                        Minor += 1;
+                        Patch = 0;
+                    }
+                    else
+                    {
+                        PreRelease = string.Empty;
+                        BuildMeta = string.Empty;
+                    }
+
+                    break;
+                }
+                case VersionBump.PreMinor:
                 {
                     Minor += 1;
                     Patch = 0;
+                    PreRelease = "0";
                     break;
                 }
                 case VersionBump.Patch:
                 {
+                    if (!IsPreRelease)
+                    {
+                        Patch += 1;
+                    }
+                    else
+                    {
+                        PreRelease = string.Empty;
+                        BuildMeta = string.Empty;
+                    }
+
+                    break;
+                }
+                case VersionBump.PrePatch:
+                {
                     Patch += 1;
+                    PreRelease = "0";
+                    break;
+                }
+                case VersionBump.PreRelease:
+                {
+                    if (!IsPreRelease)
+                    {
+                        throw new InvalidOperationException("Cannot Prerelease bump when not already a prerelease. Please use prepatch, preminor or prepatch to prepare");
+                    }
+
+                    if (!int.TryParse(PreRelease, out var preReleaseNumber))
+                    {
+                        throw new ArgumentException("Pre-release part is not numeric, cannot apply automatic prerelease roll");
+                    }
+
+                    preReleaseNumber += 1;
+                    PreRelease = (preReleaseNumber).ToString();
                     break;
                 }
                 case VersionBump.Specific:
@@ -40,10 +114,13 @@ namespace Skarp.Version.Cli
                     {
                         throw new ArgumentException($"When bump is specific, specificVersionToApply must be provided");
                     }
-                    var specific = SemVer.FromString(specificVersionToApply);
+
+                    var specific = FromString(specificVersionToApply);
                     Major = specific.Major;
                     Minor = specific.Minor;
                     Patch = specific.Patch;
+                    PreRelease = specific.PreRelease;
+                    BuildMeta = specific.BuildMeta;
                     break;
                 }
                 default:
@@ -51,13 +128,37 @@ namespace Skarp.Version.Cli
                     throw new ArgumentOutOfRangeException($"VersionBump : {bump} not supported");
                 }
             }
+            
+        }
+
+        public bool IsPreRelease => !string.IsNullOrWhiteSpace(PreRelease);
+
+        /// <summary>
+        /// Serialize the parsed version information into a SemVer version string including pre and build meta
+        /// </summary>
+        /// <returns></returns>
+        public string ToSemVerVersionString()
+        {
+            var sb = new StringBuilder();
+            sb.Append($"{Major}.{Minor}.{Patch}");
+
+            if (!string.IsNullOrWhiteSpace(PreRelease))
+            {
+                sb.AppendFormat("-{0}", PreRelease);
+                if (!string.IsNullOrWhiteSpace(BuildMeta))
+                {
+                    sb.AppendFormat("+{0}", BuildMeta);
+                }
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>
-        /// Serialize the parsed version information into a version string
+        /// Returns a simple version string including only major.minor.patch
         /// </summary>
         /// <returns></returns>
-        public string ToVersionString()
+        public string ToSimpleVersionString()
         {
             return $"{Major}.{Minor}.{Patch}";
         }
@@ -69,30 +170,21 @@ namespace Skarp.Version.Cli
         /// <returns></returns>
         public static SemVer FromString(string versionString)
         {
-            var parts = versionString.Trim().Split('.');
-            if(parts.Length == 0)
+            var matches = VersionPartRegex.Match(versionString);
+            if (!matches.Success)
             {
-                throw new ArgumentException($"Malformed versionString: {versionString}", nameof(versionString));
+                throw new ArgumentException($"Invalid SemVer version string: {versionString}", nameof(versionString));
             }
 
+            // Groups [0] is the full string , then we have the version parts after that
             return new SemVer
             {
-                Major = SafeArrayGet(parts, 0),
-                Minor = SafeArrayGet(parts, 1),
-                Patch = SafeArrayGet(parts, 2),
+                Major = Convert.ToInt32(matches.Groups[1].Value),
+                Minor = Convert.ToInt32(matches.Groups[2].Value),
+                Patch = Convert.ToInt32(matches.Groups[3].Value),
+                PreRelease = matches.Groups[4].Value,
+                BuildMeta = matches.Groups[5].Value,
             };
-        }
-
-        private static int SafeArrayGet(string[] array, int index)
-        {
-            if(index > array.Length-1) return 0;
-
-            var value = array[index];
-            if(!VersionPartRegex.IsMatch(value))
-            {
-                throw new ArgumentException($"Malformed version part: {value}", "versionString");
-            }
-            return Convert.ToInt32(value);
         }
 
         /// <summary>
@@ -112,5 +204,15 @@ namespace Skarp.Version.Cli
         /// </summary>
         /// <returns></returns>
         public int Patch { get; private set; }
+
+        /// <summary>
+        /// Pre-release semver 2 information (the stuff added with a dash after version)
+        /// </summary>
+        public string PreRelease { get; set; }
+
+        /// <summary>
+        /// Build mtadata semver 2 information (the stuff added with a + sign after PreRelease info)
+        /// </summary>
+        public string BuildMeta { get; set; }
     }
 }

--- a/src/VersionBump.cs
+++ b/src/VersionBump.cs
@@ -11,6 +11,17 @@ namespace Skarp.Version.Cli
 
         Patch,
 
+        PreMajor,
+        
+        PreMinor,
+        
+        PrePatch,
+     
+        /// <summary>
+        /// Increment the PreRelease indetifier (if it is numeric and rolled by this tool)
+        /// </summary>
+        PreRelease,
+        
         /// <summary>
         /// Apply a specific, given, version to the project file
         /// </summary>

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -9,7 +9,7 @@
         public string CsProjFilePath { get; set; }
 
         public OutputFormat OutputFormat { get; set; }
-        
+
         /// <summary>
         /// Whether or not to do version control changes like
         /// commit and tag.
@@ -20,5 +20,10 @@
         /// Whether dry run is enabled and thus all mutations should be disabled
         /// </summary>
         public bool DryRun { get; set; }
+
+        /// <summary>
+        /// Build meta for a pre-release tag passed via CLI arguments
+        /// </summary>
+        public string BuildMeta { get; set; }
     }
 }

--- a/test/CsProj/ProjectFileParserTest.cs
+++ b/test/CsProj/ProjectFileParserTest.cs
@@ -23,15 +23,16 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
                                      "<PackageId>Unit.Testing.Library</PackageId>" +
                                      "<Version>1.0.0</Version>" +
+                                     "<PackageVersion>1.0.0-1+master</PackageVersion>" +
                                      "</PropertyGroup>" +
                                      "</Project>";
 
             parser.Load(csProjXml);
             Assert.Equal("1.0.0", parser.Version);
-        }
-
+            Assert.Equal("1.0.0-1+master", parser.PackageVersion);
+        } 
         [Fact]
-        public void BailsWhenNoVersionIsDefined()
+        public void CanParse_when_version_and_package_version_missing()
         {
             const string csProjXml = "<Project Sdk=\"Microsoft.NET.Sdk\">"+
                                      "<PropertyGroup>" + 
@@ -41,14 +42,11 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            var ex = Assert.Throws<ArgumentException>(() => 
-                parser.Load(csProjXml)
-            );
-            
-            Assert.Contains($"Provided csproj file does not contain a <Version>", ex.Message);
-            Assert.Equal("version", ex.ParamName);
+            parser.Load(csProjXml);
+            Assert.Equal("0.0.0", parser.Version);
+            Assert.Equal("0.0.0", parser.PackageVersion);
         }
-
+        
          [Fact]
         public void BailsOnMalformedProjectFile()
         {

--- a/test/CsProj/ProjectFileVersionPatcherTest.cs
+++ b/test/CsProj/ProjectFileVersionPatcherTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Skarp.Version.Cli.CsProj;
 using Xunit;
 
@@ -12,6 +13,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                     "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
                     "<PackageId>Unit.Testing.Library</PackageId>" +
                     "<Version>1.0.0</Version>" +
+                    "<PackageVersion>1.0.0</PackageVersion>" +
                     "</PropertyGroup>" +
                     "</Project>";
 
@@ -23,12 +25,59 @@ namespace Skarp.Version.Cli.Test.CsProj
         }
 
         [Fact]
+        public void Throws_when_load_not_called()
+        {
+            var ex = Record.Exception((() => _patcher.PatchVersionField("1.0.0", "2.0.0")));
+
+            Assert.IsAssignableFrom<InvalidOperationException>(ex);
+        }
+        [Fact]
         public void CanPatchVersionOnWellFormedXml()
         {
-            var newXml = _patcher.Patch(_projectXml, "1.0.0", "1.1.0");
+            _patcher.Load(_projectXml);
+            _patcher.PatchVersionField("1.0.0", "1.1.0");
+            _patcher.PatchPackageVersionField( "1.0.0", "1.1.0-0");
 
+            var newXml = _patcher.ToXml();
             Assert.NotEqual(_projectXml, newXml);
             Assert.Contains("<Version>1.1.0</Version>", newXml);
+            Assert.Contains("<PackageVersion>1.1.0-0</PackageVersion>", newXml);
+        }
+
+        [Fact]
+        public void CanPatchWhenPackageVersionIsMissing()
+        {
+            var xml = 
+            "<Project Sdk=\"Microsoft.NET.Sdk\">" +
+            "<PropertyGroup>" +
+            "<TargetFramework>netstandard1.6</TargetFramework>" +
+            "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
+            "<PackageId>Unit.Testing.Library</PackageId>" +
+            "</PropertyGroup>" +
+            "</Project>";
+            _patcher.Load(xml);
+            _patcher.PatchPackageVersionField("1.0.0", "2.0.0");
+
+            var newXml = _patcher.ToXml();
+            Assert.Contains("<PackageVersion>2.0.0</PackageVersion>", newXml);
+        }  
+        
+        [Fact]
+        public void CanPatchWhenVersionIsMissing()
+        {
+            var xml = 
+            "<Project Sdk=\"Microsoft.NET.Sdk\">" +
+            "<PropertyGroup>" +
+            "<TargetFramework>netstandard1.6</TargetFramework>" +
+            "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
+            "<PackageId>Unit.Testing.Library</PackageId>" +
+            "</PropertyGroup>" +
+            "</Project>";
+
+            _patcher.Load(xml);
+            _patcher.PatchVersionField("1.0.0", "2.0.0");
+            var newXml = _patcher.ToXml();
+            Assert.Contains("<Version>2.0.0</Version>", newXml);
         }
     }
 }

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -12,13 +12,25 @@ namespace Skarp.Version.Cli.Test
     {
         [Theory]
         [InlineData("major", VersionBump.Major)]
+        [InlineData("premajor", VersionBump.PreMajor)]
         [InlineData("minor", VersionBump.Minor)]
+        [InlineData("preminor", VersionBump.PreMinor)]
         [InlineData("patch", VersionBump.Patch)]
+        [InlineData("prepatch", VersionBump.PrePatch)]
         [InlineData("1.0.1", VersionBump.Specific)]
+        [InlineData("1.0.1-0", VersionBump.Specific)]
+        [InlineData("1.0.1-0+master", VersionBump.Specific)]
+        [InlineData("1.0.1-alpha.43+4432fsd", VersionBump.Specific)]
         public void GetVersionBumpFromRemaingArgsWork(string strVersionBump, VersionBump expectedBump)
         {
-            var args = Program.GetVersionBumpFromRemainingArgs(new List<string>() {strVersionBump}, OutputFormat.Text,
-                true, true, string.Empty);
+            var args = Program.GetVersionBumpFromRemainingArgs(
+                new List<string>() {strVersionBump},
+                OutputFormat.Text,
+                true,
+                true,
+                string.Empty,
+                string.Empty
+            );
             Assert.Equal(expectedBump, args.VersionBump);
             if (expectedBump == VersionBump.Specific)
             {
@@ -30,10 +42,17 @@ namespace Skarp.Version.Cli.Test
         public void Get_version_bump_throws_on_missing_value()
         {
             var ex = Assert.Throws<ArgumentException>(() =>
-                Program.GetVersionBumpFromRemainingArgs(new List<string>(), OutputFormat.Text, true, true,
-                    string.Empty));
+                Program.GetVersionBumpFromRemainingArgs(
+                    new List<string>(),
+                    OutputFormat.Text,
+                    true,
+                    true,
+                    string.Empty,
+                    string.Empty
+                )
+            );
             Assert.Contains(
-                $"No version bump specified, please specify one of:\n\tmajor | minor | patch | <specific version>",
+                $"No version bump specified, please specify one of:\n\tmajor | minor | patch | premajor | preminor | prepatch | <specific version>",
                 ex.Message);
             Assert.Equal("versionBump", ex.ParamName);
         }
@@ -44,8 +63,15 @@ namespace Skarp.Version.Cli.Test
             const string invalidVersion = "invalid-version";
 
             var ex = Assert.Throws<ArgumentException>(() =>
-                Program.GetVersionBumpFromRemainingArgs(new List<string> {invalidVersion}, OutputFormat.Text, true,
-                    true, string.Empty));
+                Program.GetVersionBumpFromRemainingArgs(
+                    new List<string> {invalidVersion},
+                    OutputFormat.Text,
+                    true,
+                    true,
+                    string.Empty,
+                    string.Empty
+                )
+            );
             Assert.Contains($"Invalid SemVer version string: {invalidVersion}",
                 ex.Message);
             Assert.Equal("versionString", ex.ParamName);

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -46,7 +46,7 @@ namespace Skarp.Version.Cli.Test
             var ex = Assert.Throws<ArgumentException>(() =>
                 Program.GetVersionBumpFromRemainingArgs(new List<string> {invalidVersion}, OutputFormat.Text, true,
                     true, string.Empty));
-            Assert.Contains($"Malformed version part: {invalidVersion}",
+            Assert.Contains($"Invalid SemVer version string: {invalidVersion}",
                 ex.Message);
             Assert.Equal("versionString", ex.ParamName);
         }

--- a/test/SemVerTest.cs
+++ b/test/SemVerTest.cs
@@ -5,42 +5,79 @@ namespace Skarp.Version.Cli.Test
 {
     public class SemVerTest
     {
-
         [Theory]
-        [InlineData("1.0.0", 1, 0, 0)]
-        [InlineData("0.10.0", 0, 10, 0)]
-        [InlineData("1.12.99", 1, 12, 99)]
-        [InlineData("4.99.43245", 4, 99, 43245)]
-        [InlineData("4.1.3", 4, 1, 3)]
-        [InlineData("42.4.554", 42, 4, 554)]
-        [InlineData("2.1", 2, 1, 0)]
-        [InlineData("2", 2, 0, 0)]
-        [InlineData("4.1.3.6.7.8.9", 4, 1, 3)] // too many version numbers
-        public void CanParseValidSemVers(string version, int expectedMajor, int expectedMinor, int expectedPatch)
+        // valid cases - Semver 2.0 is crazy!
+        [InlineData("1.0.0", 1, 0, 0, "", "", true)]
+        [InlineData("0.10.0", 0, 10, 0, "", "", true)]
+        [InlineData("1.12.99", 1, 12, 99, "", "", true)]
+        [InlineData("4.99.43245", 4, 99, 43245, "", "", true)]
+        [InlineData("4.1.3", 4, 1, 3, "", "", true)]
+        [InlineData("42.4.554", 42, 4, 554, "", "", true)]
+        [InlineData("3.1.554-alpha.33", 3, 1, 554, "alpha.33", "", true)]
+        [InlineData("3.1.554-alpha.33+master", 3, 1, 554, "alpha.33", "master", true)]
+        public void CanParseValidSemVers(
+            string version,
+            int expectedMajor,
+            int expectedMinor,
+            int expectedPatch,
+            string expectedPreReleaseBuildInfo,
+            string expectedBuildMeta,
+            bool isValid
+        )
         {
+            if (!isValid)
+            {
+                var ex = Record.Exception(() => SemVer.FromString(version));
+                Assert.IsAssignableFrom<ArgumentException>(ex);
+
+                return;
+            }
+
             var semver = SemVer.FromString(version);
 
             Assert.Equal(expectedMajor, semver.Major);
             Assert.Equal(expectedMinor, semver.Minor);
             Assert.Equal(expectedPatch, semver.Patch);
+            Assert.Equal(expectedPreReleaseBuildInfo, semver.PreRelease);
+            Assert.Equal(expectedBuildMeta, semver.BuildMeta);
+
+            if (!string.IsNullOrWhiteSpace(semver.PreRelease))
+            {
+                Assert.True(semver.IsPreRelease);
+            }
         }
 
         [Theory]
         [InlineData("is-this-a-version")]
         [InlineData("1,0")]
+        [InlineData("2")]
+        [InlineData("2.0")]
+        [InlineData("2.0.1.2.3.4")]
         public void BailsOnInvalidSemVers(string version)
         {
             var ex = Assert.Throws<ArgumentException>(() => SemVer.FromString(version));
             Assert.Equal("versionString", ex.ParamName);
-            Assert.Contains($"Malformed version part: {version}", ex.Message);
+            Assert.Contains($"Invalid SemVer version string: {version}", ex.Message);
         }
 
         [Theory]
-        [InlineData("1.1.0", VersionBump.Major, 2, 0, 0)]
-        [InlineData("4.1.3", VersionBump.Minor, 4, 2, 0)]
-        [InlineData("2.1", VersionBump.Patch, 2, 1, 1)]
-        [InlineData("3.2.1", VersionBump.Specific, 3, 2, 1)]
-        public void CanBumpVersions(string version, VersionBump bump, int expectedMajor, int expectedMinor, int expectedPatch)
+        [InlineData("1.1.0", VersionBump.Major, 2, 0, 0, "", "")]
+        [InlineData("1.1.0", VersionBump.PreMajor, 2, 0, 0, "0", "")]
+        [InlineData("4.1.3", VersionBump.Minor, 4, 2, 0, "", "")]
+        [InlineData("4.1.3", VersionBump.PreMinor, 4, 2, 0, "0", "")]
+        [InlineData("2.1.0", VersionBump.Patch, 2, 1, 1, "", "")]
+        [InlineData("2.1.0", VersionBump.PrePatch, 2, 1, 1, "0", "")]
+        [InlineData("3.2.1", VersionBump.Specific, 3, 2, 1, "", "")]
+        [InlineData("3.2.1-0+master", VersionBump.Specific, 3, 2, 1, "0", "master")]
+        public void CanBumpVersions(
+            string version,
+            VersionBump bump,
+            int expectedMajor,
+            int expectedMinor,
+            int expectedPatch,
+            string expectedPreRelease,
+            string expectedBuildMeta
+        )
         {
             var semver = SemVer.FromString(version);
             semver.Bump(bump, version);
@@ -48,18 +85,27 @@ namespace Skarp.Version.Cli.Test
             Assert.Equal(expectedMajor, semver.Major);
             Assert.Equal(expectedMinor, semver.Minor);
             Assert.Equal(expectedPatch, semver.Patch);
+            Assert.Equal(expectedPreRelease, semver.PreRelease);
+            Assert.Equal(expectedBuildMeta, semver.BuildMeta);
         }
-        
+
         [Theory]
         [InlineData("1.0.0", VersionBump.Major, "2.0.0")]
+        [InlineData("1.0.0", VersionBump.PreMajor, "2.0.0-0")]
         [InlineData("4.1.3", VersionBump.Minor, "4.2.0")]
-        [InlineData("2.1", VersionBump.Patch, "2.1.1")]
+        [InlineData("4.1.3", VersionBump.PreMinor, "4.2.0-0")]
+        [InlineData("2.1.0", VersionBump.Patch, "2.1.1")]
+        [InlineData("2.1.0", VersionBump.PrePatch, "2.1.1-0")]
+        [InlineData("1.1.1-42", VersionBump.Patch, "1.1.1")] // snap out of pre-release mode
+        [InlineData("1.1.1-42+master", VersionBump.Patch, "1.1.1")] // snap out of pre-release mode
+        [InlineData("1.1.1-42", VersionBump.PreRelease, "1.1.1-43")] // increment prerelease number
+        
         public void CanBumpAndSerializeStringVersion(string version, VersionBump bump, string expectedVersion)
         {
             var semver = SemVer.FromString(version);
             semver.Bump(bump);
 
-            Assert.Equal(semver.ToVersionString(), expectedVersion);
+            Assert.Equal(expectedVersion, semver.ToSemVerVersionString());
         }
     }
 }


### PR DESCRIPTION
This PR adds support for working with pre-releases

**TODO**

- [x] Update SemVer.cs to properly handle `SemVer 2.0` strings (breaking change)
- [x] Update cs proj patching engine to add / remove pre-release labels in csprof file
- [x] Add `prepatch` `preminor` and `premajor` commands (like [yarn](https://classic.yarnpkg.com/en/docs/cli/version/#toc-commands))
- [x] Add `prerelease` command to increment pre-release number
- [x] Update CLI argument parser to take in extra arguments (`buildmeta`) 

Closes #33  and #28 