### PR TITLE
pre-release allow override of default prefix

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -53,6 +53,11 @@ namespace Skarp.Version.Cli
                 "Additional build metadata to add to a `premajor`, `preminor` or `prepatch` version bump",
                 CommandOptionType.SingleValue);
             
+            var prefixOption = commandLineApplication.Option(
+                "-p | --prefix <the-prerelease-prefix>",
+                "Override the default next prefix/label for a  `premajor`, `preminor` or `prepatch` version bump",
+                CommandOptionType.SingleValue);
+            
             commandLineApplication.OnExecute(() =>
             {
                 try
@@ -88,7 +93,8 @@ namespace Skarp.Version.Cli
                         doVcs,
                         dryRunEnabled,
                         csProjectFileOption.Value(),
-                        buildMetaOption.Value()
+                        buildMetaOption.Value(),
+                        prefixOption.Value()
                     );
                     _cli.Execute(cliArgs);
 
@@ -119,12 +125,14 @@ namespace Skarp.Version.Cli
             commandLineApplication.Execute(args);
         }
 
-        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(List<string> remainingArguments,
+        internal static VersionCliArgs GetVersionBumpFromRemainingArgs(
+            List<string> remainingArguments,
             OutputFormat outputFormat,
             bool doVcs,
             bool dryRunEnabled,
-            string userSpecifiedCsProjFilePath, 
-            string userSpecifiedBuildMeta
+            string userSpecifiedCsProjFilePath,
+            string userSpecifiedBuildMeta, 
+            string preReleasePrefix
         )
         {
             if (remainingArguments == null || !remainingArguments.Any())
@@ -141,6 +149,7 @@ namespace Skarp.Version.Cli
                 DoVcs = doVcs,
                 DryRun = dryRunEnabled,
                 BuildMeta =  userSpecifiedBuildMeta,
+                PreReleasePrefix = preReleasePrefix,
             };
             var bump = VersionBump.Patch;
 

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -52,7 +52,8 @@ namespace Skarp.Version.Cli
                 SemVer.FromString(_fileParser.PackageVersion),
                 args.VersionBump,
                 args.SpecificVersionToApply,
-                args.BuildMeta
+                args.BuildMeta,
+                args.PreReleasePrefix
             );
             var newSimpleVersion = semVer.ToSimpleVersionString();
             var newSemVer = semVer.ToSemVerVersionString();

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -25,5 +25,10 @@
         /// Build meta for a pre-release tag passed via CLI arguments
         /// </summary>
         public string BuildMeta { get; set; }
+
+        /// <summary>
+        /// Override for the default `next` pre-release prefix/label
+        /// </summary>
+        public string PreReleasePrefix  { get; set; }
     }
 }

--- a/src/Versioning/SemVerBumper.cs
+++ b/src/Versioning/SemVerBumper.cs
@@ -7,11 +7,18 @@ namespace Skarp.Version.Cli.Versioning
         /// <summary>
         /// Bump the currently parsed version information with the specified <paramref name="bump"/>
         /// </summary>
+        /// <param name="currentVersion"></param>
         /// <param name="bump">The bump to apply to the version</param>
         /// <param name="specificVersionToApply">The specific version to apply if bump is Specific</param>
-        /// <param name="buildMeta"></param>
-        public SemVer Bump(SemVer currentVersion, VersionBump bump, string specificVersionToApply = "",
-            string buildMeta = "")
+        /// <param name="buildMeta">Additional build metadata to add to the final version string</param>
+        /// <param name="preReleasePrefix">Override of default `next` pre-release prefix/label</param>
+        public SemVer Bump(
+            SemVer currentVersion,
+            VersionBump bump, 
+            string specificVersionToApply = "",
+            string buildMeta = "", 
+            string preReleasePrefix = ""
+        )
         {
             var newVersion = SemVer.FromString(currentVersion.ToSemVerVersionString());
             newVersion.BuildMeta = buildMeta;
@@ -25,7 +32,7 @@ namespace Skarp.Version.Cli.Versioning
                 }
                 case VersionBump.PreMajor:
                 {
-                    HandlePreMajorBump(newVersion);
+                    HandlePreMajorBump(newVersion, preReleasePrefix);
                     break;
                 }
                 case VersionBump.Minor:
@@ -35,7 +42,7 @@ namespace Skarp.Version.Cli.Versioning
                 }
                 case VersionBump.PreMinor:
                 {
-                    HandlePreMinorBump(newVersion);
+                    HandlePreMinorBump(newVersion, preReleasePrefix);
                     break;
                 }
                 case VersionBump.Patch:
@@ -45,7 +52,7 @@ namespace Skarp.Version.Cli.Versioning
                 }
                 case VersionBump.PrePatch:
                 {
-                    HandlePrePatchBump(newVersion);
+                    HandlePrePatchBump(newVersion, preReleasePrefix);
                     break;
                 }
                 case VersionBump.PreRelease:
@@ -116,10 +123,14 @@ namespace Skarp.Version.Cli.Versioning
             newVersion.PreRelease = $"{preReleaseLabel}.{preReleaseNumber}";
         }
 
-        private static void HandlePrePatchBump(SemVer newVersion)
+        private static void HandlePrePatchBump(SemVer newVersion, string preReleasePrefix)
         {
+            if (string.IsNullOrWhiteSpace(preReleasePrefix))
+            {
+                preReleasePrefix = "next";
+            }
             newVersion.Patch += 1;
-            newVersion.PreRelease = "next.0";
+            newVersion.PreRelease = $"{preReleasePrefix}.0";
         }
 
         private void HandlePatchBump(SemVer newVersion)
@@ -135,11 +146,16 @@ namespace Skarp.Version.Cli.Versioning
             }
         }
 
-        private void HandlePreMinorBump(SemVer newVersion)
+        private void HandlePreMinorBump(SemVer newVersion, string preReleasePrefix)
         {
+            if (string.IsNullOrWhiteSpace(preReleasePrefix))
+            {
+                preReleasePrefix = "next";
+            }
+            
             newVersion.Minor += 1;
             newVersion.Patch = 0;
-            newVersion.PreRelease = "next.0";
+            newVersion.PreRelease = $"{preReleasePrefix}.0";
         }
 
         private void HandleMinorBump(SemVer newVersion)
@@ -156,12 +172,17 @@ namespace Skarp.Version.Cli.Versioning
             }
         }
 
-        private void HandlePreMajorBump(SemVer newVersion)
+        private void HandlePreMajorBump(SemVer newVersion, string preReleasePrefix)
         {
+            if (string.IsNullOrWhiteSpace(preReleasePrefix))
+            {
+                preReleasePrefix = "next";
+            }
+            
             newVersion.Major += 1;
             newVersion.Minor = 0;
             newVersion.Patch = 0;
-            newVersion.PreRelease = "next.0";
+            newVersion.PreRelease = $"{preReleasePrefix}.0";
         }
 
         private void HandleMajorBump(SemVer newVersion)

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -12,7 +12,7 @@
     <Description>A dotnet core global tool for changing your csproj version and automatically comitting and tagging - npm version style.</Description>
     <PackageTags>core;version;npm version;version patch;</PackageTags>
     <PackageProjectUrl>https://github.com/skarpdev/dotnet-version-cli/</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/skarpdev/dotnet-version-cli/master/LICENSE</PackageLicenseUrl>
+    <PackageLicense>https://raw.githubusercontent.com/skarpdev/dotnet-version-cli/master/LICENSE</PackageLicense>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/skarpdev/dotnet-version-cli/</RepositoryUrl>

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -29,6 +29,7 @@ namespace Skarp.Version.Cli.Test
                 true,
                 true,
                 string.Empty,
+                string.Empty,
                 string.Empty
             );
             Assert.Equal(expectedBump, args.VersionBump);
@@ -47,6 +48,7 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
                     string.Empty,
                     string.Empty
                 )
@@ -68,6 +70,7 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
                     string.Empty,
                     string.Empty
                 )

--- a/test/Versioning/SemVerBumperTests.cs
+++ b/test/Versioning/SemVerBumperTests.cs
@@ -11,6 +11,7 @@ namespace Skarp.Version.Cli.Test.Versioning
         {
             _bumper = new SemVerBumper();
         }
+
         [Theory]
         [InlineData("1.1.0", VersionBump.Major, 2, 0, 0, "", "")]
         [InlineData("1.1.0", VersionBump.PreMajor, 2, 0, 0, "next.0", "")]
@@ -57,6 +58,21 @@ namespace Skarp.Version.Cli.Test.Versioning
         public void CanBumpAndSerializeStringVersion(string version, VersionBump bump, string expectedVersion)
         {
             var semver = _bumper.Bump(SemVer.FromString(version), bump);
+            Assert.Equal(expectedVersion, semver.ToSemVerVersionString());
+        }
+
+        [Theory]
+        [InlineData("1.0.0", VersionBump.PreMajor, "2.0.0-alpha.0", "alpha")]
+        [InlineData("1.0.0", VersionBump.PreMinor, "1.1.0-beta.0", "beta")]
+        [InlineData("1.0.0", VersionBump.PrePatch, "1.0.1-pre.0", "pre")]
+        public void Respects_custom_pre_release_prefix(
+            string version,
+            VersionBump bump,
+            string expectedVersion,
+            string prefix
+        )
+        {
+            var semver = _bumper.Bump(SemVer.FromString(version), bump, preReleasePrefix: prefix);
             Assert.Equal(expectedVersion, semver.ToSemVerVersionString());
         }
     }


### PR DESCRIPTION
This PR adds support for overriding the default `next` pre-release prefix by means of the `-p|--prefix` cli argument.

Mentions #33