### PR TITLE
pre-release don't use PackageVersion

### DIFF
--- a/src/CsProj/ProjectFileVersionPatcher.cs
+++ b/src/CsProj/ProjectFileVersionPatcher.cs
@@ -27,19 +27,6 @@ namespace Skarp.Version.Cli.CsProj
         }
 
         /// <summary>
-        /// Replace the existing PackageVersion number in the csproj xml file
-        /// </summary>
-        /// <param name="oldVersion">Old version to replace</param>
-        /// <param name="newVersion">New version to insert</param>
-        /// <returns></returns>
-        /// <exception cref="NotSupportedException"></exception>
-        public virtual void PatchPackageVersionField(string oldVersion, string newVersion)
-        {
-            var elementName = "PackageVersion";
-            PatchGenericField(elementName, oldVersion, newVersion);
-        }
-
-        /// <summary>
         /// Helper method for patching up a generic XML field in the loaded XML
         /// </summary>
         /// <param name="elementName">The name to find and update or add it to the tree</param>

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -55,27 +55,15 @@ namespace Skarp.Version.Cli
                 args.BuildMeta,
                 args.PreReleasePrefix
             );
-            var newSimpleVersion = semVer.ToSimpleVersionString();
-            var newSemVer = semVer.ToSemVerVersionString();
+            var versionString = semVer.ToSemVerVersionString();
 
             if (!args.DryRun) // if we are not in dry run mode, then we should go ahead
             {
                 _fileVersionPatcher.Load(csProjXml);
-                if (!semVer.IsPreRelease)
-                {
-                    // When dealing with pre-releases we do not wish to bump the Version prop
-                    // This gives problems with the nuget API due to it performing version constraint checks
-                    // e.g if we pre-major to 2.0.0-1 and set version 2.0.0 then our PackageVersion is LOWER than our version.
-                    // does not fly.
-                    _fileVersionPatcher.PatchVersionField(
-                        _fileParser.Version,
-                        newSimpleVersion
-                    );
-                }
-                
-                _fileVersionPatcher.PatchPackageVersionField(
-                    _fileParser.PackageVersion,
-                    newSemVer
+
+                _fileVersionPatcher.PatchVersionField(
+                    _fileParser.Version,
+                    versionString
                 );
                 
                 _fileVersionPatcher.Flush(
@@ -85,8 +73,8 @@ namespace Skarp.Version.Cli
                 if (args.DoVcs)
                 {
                     // Run git commands
-                    _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{newSemVer}");
-                    _vcsTool.Tag($"v{newSemVer}");
+                    _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{versionString}");
+                    _vcsTool.Tag($"v{versionString}");
                 }
             }
 
@@ -98,7 +86,7 @@ namespace Skarp.Version.Cli
                     Version = ProductInfo.Version
                 },
                 OldVersion = _fileParser.PackageVersion,
-                NewVersion = newSemVer,
+                NewVersion = versionString,
                 ProjectFile = _fileDetector.ResolvedCsProjFile,
                 VersionStrategy = args.VersionBump.ToString().ToLowerInvariant()
             };
@@ -110,7 +98,7 @@ namespace Skarp.Version.Cli
             }
             else
             {
-                Console.WriteLine($"Bumped {_fileDetector.ResolvedCsProjFile} to version {newSemVer}");
+                Console.WriteLine($"Bumped {_fileDetector.ResolvedCsProjFile} to version {versionString}");
             }
 
             return theOutput;

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -6,7 +6,7 @@
     <ToolCommandName>dotnet-version</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>Skarp.Version.Cli</RootNamespace>
-    <Version>1.1.2</Version>
+    <Version>2.0.0-next.5</Version>
     <Title>dotnet-version-cli</Title>
     <Authors>nover</Authors>
     <Description>A dotnet core global tool for changing your csproj version and automatically comitting and tagging - npm version style.</Description>
@@ -18,7 +18,6 @@
     <RepositoryUrl>https://github.com/skarpdev/dotnet-version-cli/</RepositoryUrl>
     <PackageId>dotnet-version-cli</PackageId>
     <Company>SKARP ApS</Company>
-    <PackageVersion>2.0.0-next.5</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/test/CsProj/ProjectFileVersionPatcherTest.cs
+++ b/test/CsProj/ProjectFileVersionPatcherTest.cs
@@ -35,32 +35,12 @@ namespace Skarp.Version.Cli.Test.CsProj
         public void CanPatchVersionOnWellFormedXml()
         {
             _patcher.Load(_projectXml);
-            _patcher.PatchVersionField("1.0.0", "1.1.0");
-            _patcher.PatchPackageVersionField( "1.0.0", "1.1.0-0");
+            _patcher.PatchVersionField("1.0.0", "1.1.0-0");
 
             var newXml = _patcher.ToXml();
             Assert.NotEqual(_projectXml, newXml);
-            Assert.Contains("<Version>1.1.0</Version>", newXml);
-            Assert.Contains("<PackageVersion>1.1.0-0</PackageVersion>", newXml);
+            Assert.Contains("<Version>1.1.0-0</Version>", newXml);
         }
-
-        [Fact]
-        public void CanPatchWhenPackageVersionIsMissing()
-        {
-            var xml = 
-            "<Project Sdk=\"Microsoft.NET.Sdk\">" +
-            "<PropertyGroup>" +
-            "<TargetFramework>netstandard1.6</TargetFramework>" +
-            "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
-            "<PackageId>Unit.Testing.Library</PackageId>" +
-            "</PropertyGroup>" +
-            "</Project>";
-            _patcher.Load(xml);
-            _patcher.PatchPackageVersionField("1.0.0", "2.0.0");
-
-            var newXml = _patcher.ToXml();
-            Assert.Contains("<PackageVersion>2.0.0</PackageVersion>", newXml);
-        }  
         
         [Fact]
         public void CanPatchWhenVersionIsMissing()

--- a/test/VersionCliTest.cs
+++ b/test/VersionCliTest.cs
@@ -108,13 +108,7 @@ namespace Skarp.Version.Cli.Test
                     A<string>.That.Matches(newVer => newVer == "2.0.0")
                 ))
                 .MustHaveHappened(Repeated.Exactly.Once);
-            
-            A.CallTo(() => _filePatcher.PatchPackageVersionField(
-                    A<string>.That.Matches(ver => ver == "1.2.1"),
-                    A<string>.That.Matches(newVer => newVer == "2.0.0")
-                ))
-                .MustHaveHappened(Repeated.Exactly.Once);
-            
+
             A.CallTo(() => _filePatcher.Flush(
                     A<string>.That.Matches(path => path == csProjFilePath)))
                 .MustHaveHappened(Repeated.Exactly.Once);
@@ -149,12 +143,6 @@ namespace Skarp.Version.Cli.Test
 
             // Verify
             A.CallTo(() => _filePatcher.PatchVersionField(
-                    A<string>._,
-                    A<string>._
-                ))
-                .MustNotHaveHappened();
-            
-            A.CallTo(() => _filePatcher.PatchPackageVersionField(
                     A<string>.That.Matches(ver => ver == "1.2.1"),
                     A<string>.That.Matches(newVer => newVer == "2.0.0-next.0")
                 ))
@@ -194,12 +182,6 @@ namespace Skarp.Version.Cli.Test
 
             // Verify
             A.CallTo(() => _filePatcher.PatchVersionField(
-                    A<string>._,
-                    A<string>._
-                ))
-                .MustNotHaveHappened();
-
-            A.CallTo(() => _filePatcher.PatchPackageVersionField(
                     A<string>.That.Matches(ver => ver == "1.2.1"),
                     "2.0.0-beta.0"
                 ))
@@ -239,12 +221,6 @@ namespace Skarp.Version.Cli.Test
 
             // Verify
             A.CallTo(() => _filePatcher.PatchVersionField(
-                    A<string>._,
-                    A<string>._
-                ))
-                .MustNotHaveHappened();
-            
-            A.CallTo(() => _filePatcher.PatchPackageVersionField(
                     A<string>.That.Matches(ver => ver == "1.2.1"),
                     A<string>.That.Matches(newVer => newVer == "2.0.0-next.0+master")
                 ))
@@ -324,13 +300,7 @@ namespace Skarp.Version.Cli.Test
                     A<string>.That.Matches(newVer => newVer == "2.0.0")
                 ))
                 .MustNotHaveHappened();
-            
-            A.CallTo(() => _filePatcher.PatchPackageVersionField(
-                    A<string>.That.Matches(ver => ver == "1.2.1"),
-                    A<string>.That.Matches(newVer => newVer == "2.0.0")
-                ))
-                .MustNotHaveHappened();
-            
+
             A.CallTo(() => _filePatcher.Flush(
                     A<string>.That.Matches(path => path == csProjFilePath)))
                 .MustNotHaveHappened();


### PR DESCRIPTION
Turns out that `dotnet pack` can now handle the fact that `Version` contain the full version number, so we have no need for the `PackageVersion`.

Mentions #33 