### PR TITLE
Use LoadOptions.PreserveWhitespace to prevent blank lines removal

### DIFF
--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -13,7 +13,7 @@ namespace Skarp.Version.Cli.CsProj
 
         public virtual void Load(string xmlDocument)
         {
-            var xml = XDocument.Parse(xmlDocument);
+            var xml = XDocument.Parse(xmlDocument, LoadOptions.PreserveWhitespace);
 
             // Project should be root of the document
             var project = xml.Elements("Project");

--- a/src/CsProj/ProjectFileVersionPatcher.cs
+++ b/src/CsProj/ProjectFileVersionPatcher.cs
@@ -11,7 +11,7 @@ namespace Skarp.Version.Cli.CsProj
 
         public virtual void Load(string xmlDocument)
         {
-            _doc = XDocument.Parse(xmlDocument);
+            _doc = XDocument.Parse(xmlDocument, LoadOptions.PreserveWhitespace);
         }
 
         /// <summary>


### PR DESCRIPTION
* Use `LoadOptions.PreserveWhitespace` to prevent blank lines removal.

Avoids side effect mentioned in https://github.com/skarpdev/dotnet-version-cli/issues/33#issuecomment-631905432.

I would also add tests to ensure this behavior in the future (but didn't have time). 
Feel free to do it yourself (you have permission edition over the branch).