### PR TITLE
Add dotnet 5.0 target

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,10 @@
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2019 Preview
+install:
+  - ps: >-
+      Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
+
+      ./dotnet-install.ps1 --Version 5.0.100-rc.2.20479.15 -InstallDir 'C:\Program Files\dotnet'
 environment:
   SONARCLOUD_TOKEN:
     secure: zP3yL8OgEY/gjfooti1esakQ0qHOwPl0GOoGugNS+61PxWOphHIndkOP/G3Glq96

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-version</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
This PR:

- installs dotnet 5.0 RC2 on appveyor as they have no image yet (fix with #63 at some point)
- targets the CLI for `net5.0` along with the rest of the targets

Closes #61 