### PR TITLE
Added cli arg to allow altering the commit message

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -54,6 +54,11 @@ namespace Skarp.Version.Cli
                 "Override the default next prefix/label for a  `premajor`, `preminor` or `prepatch` version bump",
                 CommandOptionType.SingleValue);
 
+            var commitMessage = commandLineApplication.Option(
+                "-m | --message <the-commit-message>",
+                "Set commit's message. Defaults to 'v<version>'",
+                CommandOptionType.SingleValue);
+
             commandLineApplication.OnExecute(() =>
             {
                 try
@@ -90,7 +95,8 @@ namespace Skarp.Version.Cli
                         dryRunEnabled,
                         csProjectFileOption.Value(),
                         buildMetaOption.Value(),
-                        prefixOption.Value()
+                        prefixOption.Value(),
+                        commitMessage.Value()
                     );
                     _cli.Execute(cliArgs);
 
@@ -128,7 +134,8 @@ namespace Skarp.Version.Cli
             bool dryRunEnabled,
             string userSpecifiedCsProjFilePath,
             string userSpecifiedBuildMeta,
-            string preReleasePrefix
+            string preReleasePrefix,
+            string commitMessage
         )
         {
             if (remainingArguments == null || !remainingArguments.Any())
@@ -146,6 +153,7 @@ namespace Skarp.Version.Cli
                 DryRun = dryRunEnabled,
                 BuildMeta = userSpecifiedBuildMeta,
                 PreReleasePrefix = preReleasePrefix,
+                CommitMessage = commitMessage
             };
             var bump = VersionBump.Patch;
 

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -65,7 +65,7 @@ namespace Skarp.Version.Cli
                     _fileParser.Version,
                     versionString
                 );
-                
+
                 _fileVersionPatcher.Flush(
                     _fileDetector.ResolvedCsProjFile
                 );
@@ -73,7 +73,15 @@ namespace Skarp.Version.Cli
                 if (args.DoVcs)
                 {
                     // Run git commands
-                    _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{versionString}");
+                    if (string.IsNullOrEmpty(args.CommitMessage))
+                    {
+                        _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{versionString}");
+                    }
+                    else
+                    {
+                        _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, args.CommitMessage);
+                    }
+
                     _vcsTool.Tag($"v{versionString}");
                 }
             }

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -30,5 +30,10 @@
         /// Override for the default `next` pre-release prefix/label
         /// </summary>
         public string PreReleasePrefix  { get; set; }
+
+        /// <summary>
+        /// Set commit's message
+        /// </summary>
+        public string CommitMessage { get; set; }
     }
 }

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -30,6 +30,7 @@ namespace Skarp.Version.Cli.Test
                 true,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty
             );
             Assert.Equal(expectedBump, args.VersionBump);
@@ -48,6 +49,7 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
                     string.Empty,
                     string.Empty,
                     string.Empty
@@ -69,6 +71,7 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
                     string.Empty,
                     string.Empty,
                     string.Empty


### PR DESCRIPTION
I've added a new cli arg, which allow user override defaults commit message.

I've used the same flag used in git cli, -m, --message to set the commit message.

I've also added new tests to test this new functionality.

Resolves #6 