### PR TITLE
Added cli arg to allow altering the commit message and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,48 @@ $revCount = & git rev-list HEAD --count | Out-String
 dotnet version "1.0.$revCount"
 ```
 
+## Change commit message
+
+If you want to change defaults commit message, you can use the flag `-m` or `--message`.
+```bash
+$ dotnet version minor -m "Commit message"
+```
+
+There are variables availables to be set in the message
+
+`$projName` will be replaced for package title (or package id if its not defined)
+
+`$oldVer` will be replaced for old version of the package
+
+`$newVer` will be replaced for new version of the package
+```bash
+$ dotnet version minor -m "$projName bumped from v$oldVer to v$newVer"
+# This will be replaced as
+# ProjectName bumped from v1.0.0 to v2.0.0
+```
+
+
+## Change tag message
+
+If you want to change defaults tag message, you can use the flag `-t` or `--tag`.
+```bash
+$ dotnet version minor -t "Tag"
+```
+
+There are variables availables to be set in the tag
+
+`$projName` will be replaced for package title (or package id if its not defined)
+
+`$oldVer` will be replaced for old version of the package
+
+`$newVer` will be replaced for new version of the package
+```bash
+$ dotnet version minor -t "$projName bumped from v$oldVer to v$newVer"
+# This will be replaced as
+# ProjectName bumped from v1.0.0 to v2.0.0
+```
+
+
 [1]: https://docs.npmjs.com/cli/version
 [nuget-image]: https://img.shields.io/nuget/v/dotnet-version-cli.svg
 [nuget-url]: https://www.nuget.org/packages/dotnet-version-cli

--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -11,6 +11,8 @@ namespace Skarp.Version.Cli.CsProj
         
         public virtual string PackageVersion { get; private set; }
 
+        public virtual string PackageName { get; private set; }
+
         public virtual void Load(string xmlDocument)
         {
             var xml = XDocument.Parse(xmlDocument, LoadOptions.PreserveWhitespace);
@@ -41,6 +43,27 @@ namespace Skarp.Version.Cli.CsProj
                 select prop
             ).FirstOrDefault();
             PackageVersion = xPackageVersion?.Value ?? Version;
+
+            var packageId = (
+                from prop in propertyGroup.Elements()
+                where prop.Name == "PackageId"
+                select prop
+            ).FirstOrDefault();
+
+            var title = (
+                from prop in propertyGroup.Elements()
+                where prop.Name == "Title"
+                select prop
+            ).FirstOrDefault();
+            PackageName = title?.Value ?? packageId.Value;
+
+            if (string.IsNullOrEmpty(PackageName))
+            {
+                throw new ArgumentException(
+                    "The provided csproj file seems malformed - no <Title> or <PackageId> in the <PropertyGroup>",
+                    paramName: nameof(xmlDocument)
+                );
+            }
         }
     }
 }

--- a/src/CsProj/ProjectFileProperty.cs
+++ b/src/CsProj/ProjectFileProperty.cs
@@ -1,0 +1,10 @@
+﻿namespace Skarp.Version.Cli.CsProj
+{
+    public enum ProjectFileProperty
+    {
+        Version,
+        PackageVersion,
+        PackageId,
+        Title,
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -62,7 +62,7 @@ namespace Skarp.Version.Cli
 
             var vcsTag = commandLineApplication.Option(
                 "-t | --tag <git-tag>",
-                "Override the default version control system tag when is not disabled - default is 'v<version>'. Available variables: $projName, $oldVer, $newVer",
+                "Set tag's name - default is 'v<version>'. Available variables: $projName, $oldVer, $newVer",
                 CommandOptionType.SingleValue);
 
             commandLineApplication.OnExecute(() =>

--- a/src/Vcs/Git/GitVcs.cs
+++ b/src/Vcs/Git/GitVcs.cs
@@ -70,6 +70,7 @@ namespace Skarp.Version.Cli.Vcs.Git
                 return false;
             }
         }
+
         private static ProcessStartInfo CreateGitShellStartInfo(string args)
         {
             return new ProcessStartInfo("git")

--- a/src/Vcs/VcsParser.cs
+++ b/src/Vcs/VcsParser.cs
@@ -1,0 +1,30 @@
+﻿using Skarp.Version.Cli.CsProj;
+using Skarp.Version.Cli.Model;
+
+namespace Skarp.Version.Cli.Vcs
+{
+    public class VcsParser
+    {
+        public string Commit(VersionInfo verInfo, ProjectFileParser fileParser, string argMessage)
+        {
+            if (string.IsNullOrEmpty(argMessage)) return $"v{verInfo.NewVersion}";
+
+            return ReplaceVariables(verInfo, fileParser, argMessage);
+        }
+
+        public string Tag(VersionInfo verInfo, ProjectFileParser fileParser, string argTag)
+        {
+            if (string.IsNullOrEmpty(argTag)) return $"v{verInfo.NewVersion}";
+
+            return ReplaceVariables(verInfo, fileParser, argTag);
+        }
+
+        private string ReplaceVariables(VersionInfo verInfo, ProjectFileParser fileParser, string dest)
+        {
+            return dest
+                .Replace("$projName", fileParser.PackageName)
+                .Replace("$oldVer", verInfo.OldVersion)
+                .Replace("$newVer", verInfo.NewVersion);
+        }
+    }
+}

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -13,6 +13,7 @@ namespace Skarp.Version.Cli
         private readonly IVcs _vcsTool;
         private readonly ProjectFileDetector _fileDetector;
         private readonly ProjectFileParser _fileParser;
+        private readonly VcsParser _vcsParser;
         private readonly ProjectFileVersionPatcher _fileVersionPatcher;
         private readonly SemVerBumper _bumper;
 
@@ -20,6 +21,7 @@ namespace Skarp.Version.Cli
             IVcs vcsClient,
             ProjectFileDetector fileDetector,
             ProjectFileParser fileParser,
+            VcsParser vcsParser,
             ProjectFileVersionPatcher fileVersionPatcher,
             SemVerBumper bumper
         )
@@ -27,6 +29,7 @@ namespace Skarp.Version.Cli
             _vcsTool = vcsClient;
             _fileDetector = fileDetector;
             _fileParser = fileParser;
+            _vcsParser = vcsParser;
             _fileVersionPatcher = fileVersionPatcher;
             _bumper = bumper;
         }
@@ -57,27 +60,6 @@ namespace Skarp.Version.Cli
             );
             var versionString = semVer.ToSemVerVersionString();
 
-            if (!args.DryRun) // if we are not in dry run mode, then we should go ahead
-            {
-                _fileVersionPatcher.Load(csProjXml);
-
-                _fileVersionPatcher.PatchVersionField(
-                    _fileParser.Version,
-                    versionString
-                );
-                
-                _fileVersionPatcher.Flush(
-                    _fileDetector.ResolvedCsProjFile
-                );
-
-                if (args.DoVcs)
-                {
-                    // Run git commands
-                    _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, $"v{versionString}");
-                    _vcsTool.Tag($"v{versionString}");
-                }
-            }
-
             var theOutput = new VersionInfo
             {
                 Product = new ProductOutputInfo
@@ -91,6 +73,26 @@ namespace Skarp.Version.Cli
                 VersionStrategy = args.VersionBump.ToString().ToLowerInvariant()
             };
 
+            if (!args.DryRun) // if we are not in dry run mode, then we should go ahead
+            {
+                _fileVersionPatcher.Load(csProjXml);
+
+                _fileVersionPatcher.PatchVersionField(
+                    _fileParser.Version,
+                    versionString
+                );
+
+                _fileVersionPatcher.Flush(
+                    _fileDetector.ResolvedCsProjFile
+                );
+
+                if (args.DoVcs)
+                {
+                    // Run git commands
+                    _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, _vcsParser.Commit(theOutput, _fileParser, args.CommitMessage));
+                    _vcsTool.Tag(_vcsParser.Tag(theOutput, _fileParser, args.VersionControlTag));
+                }
+            }
 
             if (args.OutputFormat == OutputFormat.Json)
             {

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -49,7 +49,7 @@ namespace Skarp.Version.Cli
             }
 
             var csProjXml = _fileDetector.FindAndLoadCsProj(args.CsProjFilePath);
-            _fileParser.Load(csProjXml);
+            _fileParser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
 
             var semVer = _bumper.Bump(
                 SemVer.FromString(_fileParser.PackageVersion),
@@ -88,6 +88,7 @@ namespace Skarp.Version.Cli
 
                 if (args.DoVcs)
                 {
+                    _fileParser.Load(csProjXml, ProjectFileProperty.Title);
                     // Run git commands
                     _vcsTool.Commit(_fileDetector.ResolvedCsProjFile, _vcsParser.Commit(theOutput, _fileParser, args.CommitMessage));
                     _vcsTool.Tag(_vcsParser.Tag(theOutput, _fileParser, args.VersionControlTag));

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -30,5 +30,15 @@
         /// Override for the default `next` pre-release prefix/label
         /// </summary>
         public string PreReleasePrefix  { get; set; }
+
+        /// <summary>
+        /// Set commit's message
+        /// </summary>
+        public string CommitMessage { get; set; }
+
+        /// <summary>
+        /// Override for the default `v<version>` vcs tag
+        /// </summary>
+        public string VersionControlTag { get; set; }
     }
 }

--- a/test/CsProj/ProjectFileParserTest.cs
+++ b/test/CsProj/ProjectFileParserTest.cs
@@ -27,7 +27,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml);
+            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
             Assert.Equal("1.0.0", parser.Version);
             Assert.Equal("1.0.0-1+master", parser.PackageVersion);
         } 
@@ -42,7 +42,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml);
+            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
             Assert.Equal("0.0.0", parser.Version);
             Assert.Equal("0.0.0", parser.PackageVersion);
         }

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -30,6 +30,8 @@ namespace Skarp.Version.Cli.Test
                 true,
                 string.Empty,
                 string.Empty,
+                string.Empty,
+                string.Empty,
                 string.Empty
             );
             Assert.Equal(expectedBump, args.VersionBump);
@@ -48,6 +50,8 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
+                    string.Empty,
                     string.Empty,
                     string.Empty,
                     string.Empty
@@ -69,6 +73,8 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
+                    string.Empty,
                     string.Empty,
                     string.Empty,
                     string.Empty


### PR DESCRIPTION
I've added a new cli arg, which allow user override defaults commit message and vcs tag.

I've used the flag `-m`/`--message` for the commit message (following git cli) and `-t`/`--tag` for the tag.

I've also added new tests to test these new functionalities.

Resolves #6

Both options have the capability to replace vars in the defined strings
$projName for the package name
$oldVer for the old version
$newVer for the new version

In order to get the package name, I've added a new field to ProjectFileParser, which look up for the `<Title>` field in the `.csproj` file, and if it's not found, will look up for `<PackageId>` tag (more [info](https://docs.microsoft.com/es-es/dotnet/core/tools/csproj#title)). If neither of them are set, an exception is raised since at least `<PackageId>` must be present.