### PR TITLE
Load all properties if no properties are provided in file parser

### DIFF
--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -47,6 +47,16 @@ namespace Skarp.Version.Cli.CsProj
 
         public virtual void Load(string xmlDocument, params ProjectFileProperty[] properties)
         {
+            if (properties == null || !properties.Any())
+            {
+                properties = new[]
+                {
+                    ProjectFileProperty.Title,
+                    ProjectFileProperty.Version,
+                    ProjectFileProperty.PackageId,
+                    ProjectFileProperty.PackageVersion,
+                };
+            } 
             // Try to load xmlDocument even if there is no properties to be loaded
             // in order to verify if project file is well formed
             LoadPropertyGroup(xmlDocument);


### PR DESCRIPTION
In order to avoid loading no props at all resulting in null output from the cli

Closes #70