### PR TITLE
Add `bare` output to dump and bump commands

### DIFF
--- a/src/OutputFormat.cs
+++ b/src/OutputFormat.cs
@@ -10,6 +10,11 @@
         /// <summary>
         /// json output
         /// </summary>
-        Json
+        Json,
+        
+        /// <summary>
+        /// Bare output without extraneous information
+        /// </summary>
+        Bare
     }
 }

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -99,6 +99,10 @@ namespace Skarp.Version.Cli
             {
                 WriteJsonToStdout(theOutput);
             }
+            else if (args.OutputFormat == OutputFormat.Bare)
+            {
+                Console.WriteLine(versionString);
+            }
             else
             {
                 Console.WriteLine($"Bumped {_fileDetector.ResolvedCsProjFile} to version {versionString}");

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -110,7 +110,7 @@ namespace Skarp.Version.Cli
         public void DumpVersion(VersionCliArgs args)
         {
             var csProjXml = _fileDetector.FindAndLoadCsProj(args.CsProjFilePath);
-            _fileParser.Load(csProjXml);
+            _fileParser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
 
             if (args.OutputFormat == OutputFormat.Json)
             {
@@ -125,6 +125,10 @@ namespace Skarp.Version.Cli
                     ProjectFile = _fileDetector.ResolvedCsProjFile,
                 };
                 WriteJsonToStdout(theOutput);
+            }
+            if (args.OutputFormat == OutputFormat.Bare)
+            {
+                Console.WriteLine(_fileParser.PackageVersion);
             }
             else
             {


### PR DESCRIPTION
Which will _just_ output the version of the target csproj.

example of dump :
```
$ dotnet version --output-format=bare -f ./dotnet-version.csproj                                                                                                                                                  
2.0.0
```

And likewise for bump:
```
$ dotnet version --output-format=bare -f ./dotnet-version.csproj patch                                                                                                                                            2.0.1
```

Closes #69 