### PR TITLE
Remove requirement for having a package title

### DIFF
--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -32,15 +32,7 @@ namespace Skarp.Version.Cli.CsProj
                 case ProjectFileProperty.Title:
                     var defaultPropertyElement = LoadProperty(ProjectFileProperty.PackageId);
                     PackageName = propertyElement?.Value ?? defaultPropertyElement?.Value ?? string.Empty;
-
-                    if (string.IsNullOrEmpty(PackageName))
-                    {
-                        throw new ArgumentException(
-                            "The provided csproj file seems malformed - no <Title> or <PackageId> in the <PropertyGroup>",
-                            paramName: nameof(xmlDocument)
-                        );
-                    }
-
+                    
                     break;
             }
         }

--- a/test/CsProj/ProjectFileParserTest.cs
+++ b/test/CsProj/ProjectFileParserTest.cs
@@ -75,13 +75,9 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
                                      "</PropertyGroup>" +
                                      "</Project>";
-
-            var ex = Assert.Throws<ArgumentException>(() => 
-                parser.Load(csProjXml)
-            );
             
-            Assert.Contains($"The provided csproj file seems malformed - no <Title> or <PackageId> in the <PropertyGroup>", ex.Message);
-            Assert.Equal("xmlDocument", ex.ParamName);
+            parser.Load(csProjXml);
+            Assert.Empty(parser.PackageName);
         }
     }
 }


### PR DESCRIPTION
This was (accidentally) introduced with PR #66. The code is now
defaulting to an empty title rather than throwing an exception.

This addition of a required package name actually made the 2.1.x series an accidental breaking change.

This should fix that...