### PR TITLE
Breaking: remove support for .net 2.x, 3.x and 5.x

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -24,7 +24,7 @@ function Exec
 
 if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
 
-$Env:JAVA_HOME="C:\Program Files\Java\jdk16"
+$Env:JAVA_HOME="C:\Program Files\Java\jdk17"
 $Env:PATH=-join($Env:JAVA_HOME, ";", $Env:PATH)
 
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # dotnet-version-cli
 
-This repository contains the source code for an [npm/yarn version][1] inspired dotnet global tool for dotnet core 2.1 or newer with full [SemVer 2.0][semver2] compatibility!
+This repository contains the source code for an [npm/yarn version][1] inspired dotnet global tool for dotnet with full [SemVer 2.0][semver2] compatibility!
 
-This used to be a dotnet csproj installable `cli tool` - if you are not ready for the move to dotnet 2.1 global tools, please take a look at the last [0.7.0 release that supports csproj installation](https://github.com/skarpdev/dotnet-version-cli/blob/v0.7.0/README.md).
+This used to be a dotnet csproj installable `cli tool` - if you are not ready for the move to dotnet global tools, please take a look at the last [0.7.0 release that supports csproj installation](https://github.com/skarpdev/dotnet-version-cli/blob/v0.7.0/README.md).
 
 Once installed it provides a `dotnet version` command which allows you to easily bump `patch`, `minor` and `major` versions on your project. You can also release and manage pre-release
 vesions of your packages by using the `prepatch`, `preminor` and `premajor` commands. Once in pre-release mode you can use the `prerelease` option to update the pre-release number.

--- a/src/dotnet-version.csproj
+++ b/src/dotnet-version.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-version</ToolCommandName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/test/dotnet-version-test.csproj
+++ b/test/dotnet-version-test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>Skarp.Version.Cli.Test</RootNamespace>
     <ProjectGuid>fb420acf-9e12-42b6-b724-1eee9cbf251e</ProjectGuid>
   </PropertyGroup>


### PR DESCRIPTION
This PR removes support for these unsupported .net versions:

- 2.x
- 3.x
- 5.x

The PR also updates the CI/CD to use JDK 17, as this is required for the latest version of the Sonar scanner.

Closes #79 