### PR TITLE
Switch default version property back to Version + add CLI option

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -65,6 +65,11 @@ namespace Skarp.Version.Cli
                 "Set tag's name - default is 'v<version>'. Available variables: $projName, $oldVer, $newVer",
                 CommandOptionType.SingleValue);
 
+            var projectFilePropertyName = commandLineApplication.Option(
+                "-v | --version-property-name <property-name>",
+                "Specify which tag from <PropertyGroup> to use as the version tag. Default is Version. Available values: Version, PackageVersion.",
+                CommandOptionType.SingleValue);
+
             commandLineApplication.OnExecute(() =>
             {
                 try
@@ -103,7 +108,8 @@ namespace Skarp.Version.Cli
                         buildMetaOption.Value(),
                         prefixOption.Value(),
                         commitMessage.Value(),
-                        vcsTag.Value()
+                        vcsTag.Value(),
+                        projectFilePropertyName.Value()
                     );
                     _cli.Execute(cliArgs);
 
@@ -143,7 +149,8 @@ namespace Skarp.Version.Cli
             string userSpecifiedBuildMeta,
             string preReleasePrefix,
             string commitMessage,
-            string vcsTag
+            string vcsTag,
+            string projectFilePropertyName
         )
         {
             if (remainingArguments == null || !remainingArguments.Any())
@@ -162,8 +169,9 @@ namespace Skarp.Version.Cli
                 BuildMeta = userSpecifiedBuildMeta,
                 PreReleasePrefix = preReleasePrefix,
                 CommitMessage = commitMessage,
-                VersionControlTag = vcsTag,
+                VersionControlTag = vcsTag
             };
+            
             var bump = VersionBump.Patch;
 
             foreach (var arg in remainingArguments)
@@ -177,6 +185,11 @@ namespace Skarp.Version.Cli
 
             args.VersionBump = bump;
             args.CsProjFilePath = userSpecifiedCsProjFilePath;
+            
+            if (!string.IsNullOrEmpty(projectFilePropertyName))
+            {
+                args.ProjectFilePropertyName = Enum.Parse<ProjectFileProperty>(projectFilePropertyName, ignoreCase: true);
+            }
 
             return args;
         }

--- a/src/VersionCliArgs.cs
+++ b/src/VersionCliArgs.cs
@@ -44,8 +44,8 @@ namespace Skarp.Version.Cli
         public string VersionControlTag { get; set; }
 
         /// <summary>
-        /// Specify the Version-Tag that should be targeted. Default is PackageVersion
+        /// Specify the Version-Tag that should be targeted. Default is Version.
         /// </summary>
-        public ProjectFileProperty ProjectFilePropertyName { get; set; } = ProjectFileProperty.PackageVersion;
+        public ProjectFileProperty ProjectFilePropertyName { get; set; } = ProjectFileProperty.Version;
     }
 }

--- a/test/ProgramTest.cs
+++ b/test/ProgramTest.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using FakeItEasy;
-using Microsoft.Extensions.CommandLineUtils;
-using Microsoft.VisualStudio.TestPlatform.TestHost;
+using Skarp.Version.Cli.CsProj;
 using Xunit;
 
 namespace Skarp.Version.Cli.Test
@@ -21,13 +18,14 @@ namespace Skarp.Version.Cli.Test
         [InlineData("1.0.1-0", VersionBump.Specific)]
         [InlineData("1.0.1-0+master", VersionBump.Specific)]
         [InlineData("1.0.1-alpha.43+4432fsd", VersionBump.Specific)]
-        public void GetVersionBumpFromRemaingArgsWork(string strVersionBump, VersionBump expectedBump)
+        public void GetVersionBumpFromRemainingArgsWork(string strVersionBump, VersionBump expectedBump)
         {
             var args = Program.GetVersionBumpFromRemainingArgs(
                 new List<string>() {strVersionBump},
                 OutputFormat.Text,
                 true,
                 true,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -50,6 +48,7 @@ namespace Skarp.Version.Cli.Test
                     OutputFormat.Text,
                     true,
                     true,
+                    string.Empty,
                     string.Empty,
                     string.Empty,
                     string.Empty,
@@ -77,12 +76,55 @@ namespace Skarp.Version.Cli.Test
                     string.Empty,
                     string.Empty,
                     string.Empty,
+                    string.Empty,
                     string.Empty
                 )
             );
             Assert.Contains($"Invalid SemVer version string: {invalidVersion}",
                 ex.Message);
             Assert.Equal("versionString", ex.ParamName);
+        }
+        
+        [Fact]
+        public void DefaultsToReadingVersionStringFromVersionProperty()
+        {
+            var args = Program.GetVersionBumpFromRemainingArgs(
+                new List<string>() {"patch"},
+                OutputFormat.Text,
+                true,
+                true,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty
+            );
+            
+            Assert.Equal(ProjectFileProperty.Version, args.ProjectFilePropertyName);
+        }
+        
+        [Theory]
+        [InlineData(null, ProjectFileProperty.Version)]
+        [InlineData("", ProjectFileProperty.Version)]
+        [InlineData("verSION", ProjectFileProperty.Version)]
+        [InlineData("packageversion", ProjectFileProperty.PackageVersion)]
+        public void CanOverrideTheVersionPropertyName(string input, ProjectFileProperty expected)
+        {
+            var args = Program.GetVersionBumpFromRemainingArgs(
+                new List<string>() {"patch"},
+                OutputFormat.Text,
+                true,
+                true,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                input
+            );
+            
+            Assert.Equal(expected, args.ProjectFilePropertyName);
         }
     }
 }


### PR DESCRIPTION
This PR...

- changes the default `<PropertyGroup>` property to read the version from, back to `<Version>`
- adds CLI option for changing which property to read

Fixes #110 

I suggest releasing this as a patch. Technically it is a breaking change, but I would argue that it is a fix to get back to the way it should have been working already.