### PR TITLE
fix: mishandling of version and packageversion

### DIFF
--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -93,25 +93,13 @@ namespace Skarp.Version.Cli.CsProj
 
         public string GetHumanReadableVersionFromSource()
         {
-            switch (VersionSource)
+            return VersionSource switch
             {
-                case ProjectFileProperty.Version:
-                {
-                    return Version;
-                }
-                case ProjectFileProperty.VersionPrefix:
-                {
-                    return $"{VersionPrefix}-{VersionSuffix}";
-                }
-                case ProjectFileProperty.PackageVersion:
-                {
-                    return PackageVersion;
-                }
-                default:
-                {
-                    throw new ArgumentOutOfRangeException($"Unknown version source {VersionSource}");
-                }
-            }
+                ProjectFileProperty.Version => Version,
+                ProjectFileProperty.VersionPrefix => $"{VersionPrefix}-{VersionSuffix}",
+                ProjectFileProperty.PackageVersion => PackageVersion,
+                _ => throw new ArgumentOutOfRangeException($"Unknown version source {VersionSource}")
+            };
         }
 
         private XElement LoadProperty(ProjectFileProperty property)

--- a/src/CsProj/ProjectFileParser.cs
+++ b/src/CsProj/ProjectFileParser.cs
@@ -17,15 +17,26 @@ namespace Skarp.Version.Cli.CsProj
 
         public virtual string VersionSuffix { get; private set; }
 
-        public ProjectFileProperty VersionSource { get
+        public virtual ProjectFileProperty DesiredVersionSource { get; private set; }
+
+        public ProjectFileProperty VersionSource
+        {
+            get
             {
-                return !string.IsNullOrEmpty(Version) ? ProjectFileProperty.Version : ProjectFileProperty.VersionPrefix;
-            } 
+                if (DesiredVersionSource == ProjectFileProperty.Version)
+                {
+                    return string.IsNullOrWhiteSpace(Version)
+                        ? ProjectFileProperty.VersionPrefix
+                        : ProjectFileProperty.Version;
+                }
+
+                return ProjectFileProperty.PackageVersion;
+            }
         }
 
         private IEnumerable<XElement> _propertyGroup { get; set; }
 
-        public virtual void Load(string xmlDocument, ProjectFileProperty property)
+        protected virtual void Load(string xmlDocument, ProjectFileProperty property)
         {
             LoadPropertyGroup(xmlDocument);
 
@@ -52,8 +63,11 @@ namespace Skarp.Version.Cli.CsProj
             }
         }
 
-        public virtual void Load(string xmlDocument, params ProjectFileProperty[] properties)
+
+        public virtual void Load(string xmlDocument, ProjectFileProperty versionSource,  params ProjectFileProperty[] properties)
         {
+            DesiredVersionSource = versionSource;
+            
             if (properties == null || !properties.Any())
             {
                 properties = new[]
@@ -66,6 +80,7 @@ namespace Skarp.Version.Cli.CsProj
                     ProjectFileProperty.VersionSuffix
                 };
             }
+
             // Try to load xmlDocument even if there is no properties to be loaded
             // in order to verify if project file is well formed
             LoadPropertyGroup(xmlDocument);
@@ -73,6 +88,29 @@ namespace Skarp.Version.Cli.CsProj
             foreach (var property in properties)
             {
                 Load(xmlDocument, property);
+            }
+        }
+
+        public string GetHumanReadableVersionFromSource()
+        {
+            switch (VersionSource)
+            {
+                case ProjectFileProperty.Version:
+                {
+                    return Version;
+                }
+                case ProjectFileProperty.VersionPrefix:
+                {
+                    return $"{VersionPrefix}-{VersionSuffix}";
+                }
+                case ProjectFileProperty.PackageVersion:
+                {
+                    return PackageVersion;
+                }
+                default:
+                {
+                    throw new ArgumentOutOfRangeException($"Unknown version source {VersionSource}");
+                }
             }
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -95,7 +95,9 @@ namespace Skarp.Version.Cli
                         {
                             OutputFormat = outputFormat,
                             CsProjFilePath = csProjectFileOption.Value(),
+                            ProjectFilePropertyName = Enum.Parse<ProjectFileProperty>(projectFilePropertyName.Value(), ignoreCase: true),
                         });
+                        
                         return 0;
                     }
 

--- a/src/VersionCli.cs
+++ b/src/VersionCli.cs
@@ -137,7 +137,8 @@ namespace Skarp.Version.Cli
         public void DumpVersion(VersionCliArgs args)
         {
             var csProjXml = _fileDetector.FindAndLoadCsProj(args.CsProjFilePath);
-            _fileParser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
+            _fileParser.Load(csProjXml, args.ProjectFilePropertyName);
+            
             switch (args.OutputFormat)
             {
                 case OutputFormat.Json:
@@ -148,17 +149,18 @@ namespace Skarp.Version.Cli
                             Name = ProductInfo.Name,
                             Version = ProductInfo.Version
                         },
-                        CurrentVersion = _fileParser.PackageVersion,
+                        CurrentVersion = _fileParser.GetHumanReadableVersionFromSource(),
                         ProjectFile = _fileDetector.ResolvedCsProjFile,
                     };
                     WriteJsonToStdout(theOutput);
                     break;
                 case OutputFormat.Bare:
-                    Console.WriteLine(_fileParser.PackageVersion);
+                    Console.WriteLine(_fileParser.GetHumanReadableVersionFromSource());
                     break;
                 case OutputFormat.Text:
                 default:
-                    Console.WriteLine("Project version is: {0}\t{1}", Environment.NewLine, _fileParser.PackageVersion);
+                    Console.WriteLine("Project version is: {0}\t{1}", Environment.NewLine,
+                        _fileParser.GetHumanReadableVersionFromSource());
                     break;
             }
         }

--- a/test/CsProj/ProjectFileParserTest.cs
+++ b/test/CsProj/ProjectFileParserTest.cs
@@ -11,7 +11,6 @@ namespace Skarp.Version.Cli.Test.CsProj
         public ProjectFileParserTest()
         {
             parser = new ProjectFileParser();
-
         }
 
         [Fact]
@@ -27,10 +26,11 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
+            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
             Assert.Equal("1.0.0", parser.Version);
             Assert.Equal("1.0.0-1+master", parser.PackageVersion);
         }
+
         [Fact]
         public void CanParse_when_version_and_package_version_missing()
         {
@@ -42,7 +42,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion);
+            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.PackageVersion, ProjectFileProperty.Version);
             Assert.Empty(parser.Version);
             Assert.Empty(parser.PackageVersion);
         }
@@ -59,7 +59,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</Projectttttt>";
 
             var ex = Assert.Throws<ArgumentException>(() =>
-                parser.Load(csProjXml)
+                parser.Load(csProjXml, ProjectFileProperty.Version)
             );
 
             Assert.Contains($"The provided csproj file seems malformed - no <Project> in the root", ex.Message);
@@ -76,7 +76,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml);
+            parser.Load(csProjXml, ProjectFileProperty.Version);
             Assert.Empty(parser.PackageName);
         }
 
@@ -91,7 +91,7 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml);
+            parser.Load(csProjXml, ProjectFileProperty.Version);
             Assert.Empty(parser.PackageName);
             Assert.Equal("1.0.0", parser.VersionPrefix);
             Assert.Empty(parser.VersionSuffix);
@@ -111,11 +111,63 @@ namespace Skarp.Version.Cli.Test.CsProj
                                      "</PropertyGroup>" +
                                      "</Project>";
 
-            parser.Load(csProjXml);
+            parser.Load(csProjXml, ProjectFileProperty.Version);
             Assert.Empty(parser.PackageName);
             Assert.Equal("1.0.0", parser.VersionPrefix);
             Assert.Equal("SNAPSHOT", parser.VersionSuffix);
             Assert.Empty(parser.Version);
+        }
+
+        [Fact]
+        public void Can_get_human_readable_version_from_version()
+        {
+            const string csProjXml = "<Project Sdk=\"Microsoft.NET.Sdk\">" +
+                                     "<PropertyGroup>" +
+                                     "<TargetFramework>netstandard1.6</TargetFramework>" +
+                                     "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
+                                     "<PackageId>Unit.Testing.Library</PackageId>" +
+                                     "<Version>1.0.0</Version>" +
+                                     "<PackageVersion>1.0.0-1+master</PackageVersion>" +
+                                     "</PropertyGroup>" +
+                                     "</Project>";
+
+            parser.Load(csProjXml, ProjectFileProperty.Version);
+            Assert.Equal("1.0.0", parser.GetHumanReadableVersionFromSource());
+        }
+
+        [Fact]
+        public void Can_get_human_readable_version_from_packageversion()
+        {
+            const string csProjXml = "<Project Sdk=\"Microsoft.NET.Sdk\">" +
+                                     "<PropertyGroup>" +
+                                     "<TargetFramework>netstandard1.6</TargetFramework>" +
+                                     "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
+                                     "<PackageId>Unit.Testing.Library</PackageId>" +
+                                     "<Version>1.0.0</Version>" +
+                                     "<PackageVersion>1.0.0-1+master</PackageVersion>" +
+                                     "</PropertyGroup>" +
+                                     "</Project>";
+
+            parser.Load(csProjXml, ProjectFileProperty.PackageVersion);
+            Assert.Equal("1.0.0-1+master", parser.GetHumanReadableVersionFromSource());
+        }
+
+        [Fact]
+        public void Can_get_human_readable_version_from_versionprefix()
+        {
+            const string csProjXml = "<Project Sdk=\"Microsoft.NET.Sdk\">" +
+                                     "<PropertyGroup>" +
+                                     "<TargetFramework>netstandard1.6</TargetFramework>" +
+                                     "<RootNamespace>Unit.For.The.Win</RootNamespace>" +
+                                     "<PackageId>Unit.Testing.Library</PackageId>" +
+                                     "<VersionPrefix>1.0.0</VersionPrefix>" +
+                                     "<VersionSuffix>master</VersionSuffix>" +
+                                     "</PropertyGroup>" +
+                                     "</Project>";
+
+            parser.Load(csProjXml, ProjectFileProperty.Version, ProjectFileProperty.Version, ProjectFileProperty.VersionPrefix,
+                ProjectFileProperty.VersionSuffix, ProjectFileProperty.PackageVersion);
+            Assert.Equal("1.0.0-master", parser.GetHumanReadableVersionFromSource());
         }
     }
 }

--- a/test/VersionCliTest.cs
+++ b/test/VersionCliTest.cs
@@ -25,24 +25,25 @@ namespace Skarp.Version.Cli.Test
             _fileParser = A.Fake<ProjectFileParser>();
             _vcsParser = A.Fake<VcsParser>();
             _filePatcher = A.Fake<ProjectFileVersionPatcher>();
-            
+
             A.CallTo(() => _fileDetector.FindAndLoadCsProj(A<string>._)).Returns("<Project/>");
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.VersionPrefix).Returns("2.0.1");
             A.CallTo(() => _fileParser.VersionSuffix).Returns("DEVELOPMENT");
+            A.CallTo(() => _fileParser.DesiredVersionSource).Returns(ProjectFileProperty.Version);
 
             _cli = new VersionCli(
-                    _vcsTool,
-                    _fileDetector,
-                    _fileParser,
-                    _vcsParser,
-                    _filePatcher,
-                    new SemVerBumper()
-                );
+                _vcsTool,
+                _fileDetector,
+                _fileParser,
+                _vcsParser,
+                _filePatcher,
+                new SemVerBumper()
+            );
         }
 
         [Fact]
@@ -52,7 +53,8 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _fileParser.VersionPrefix).Returns("2.0.1");
             A.CallTo(() => _fileParser.VersionSuffix).Returns("DEVELOPMENT");
 
-            var output = _cli.Execute(new VersionCliArgs { OutputFormat = OutputFormat.Bare, VersionBump = VersionBump.None, DryRun = true });
+            var output = _cli.Execute(new VersionCliArgs
+                { OutputFormat = OutputFormat.Bare, VersionBump = VersionBump.None, DryRun = true });
 
             Assert.Equal("2.0.1-DEVELOPMENT", output.OldVersion);
         }
@@ -62,10 +64,11 @@ namespace Skarp.Version.Cli.Test
         {
             A.CallTo(() => _vcsTool.IsVcsToolPresent()).Returns(false);
 
-            var ex = Assert.Throws<OperationCanceledException>(() => _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.Major, DoVcs = true}));
+            var ex = Assert.Throws<OperationCanceledException>(() =>
+                _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true }));
             Assert.Equal("Unable to find the vcs tool _FAKE_ in your path", ex.Message);
         }
-        
+
         [Fact]
         public void VersionCli_doesNotThrow_when_vcs_tool_is_not_present_if_doVcs_is_false()
         {
@@ -73,7 +76,7 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
-            _cli.Execute(new VersionCliArgs {VersionBump = VersionBump.Major, DoVcs = false});
+            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = false });
         }
 
         [Fact]
@@ -82,11 +85,12 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _vcsTool.IsVcsToolPresent()).Returns(true);
             A.CallTo(() => _vcsTool.IsRepositoryClean()).Returns(false);
 
-            var ex = Assert.Throws<OperationCanceledException>(() => _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.Major, DoVcs = true}));
+            var ex = Assert.Throws<OperationCanceledException>(() =>
+                _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true }));
             Assert.Equal("You currently have uncomitted changes in your repository, please commit these and try again",
                 ex.Message);
         }
-        
+
         [Fact]
         public void VersionCli_doesNotThrow_when_repo_is_not_clean_if_doVcs_is_false()
         {
@@ -95,7 +99,7 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
-            _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.Major, DoVcs = false});
+            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = false });
         }
 
         [Fact]
@@ -111,12 +115,12 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.Major, DoVcs = true, DryRun = false});
+            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -135,8 +139,8 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _vcsTool.Tag(
                     A<string>.That.Matches(tag => tag == "v2.0.0")))
                 .MustHaveHappened(Repeated.Exactly.Once);
-        } 
-        
+        }
+
         [Fact]
         public void VersionCli_can_bump_pre_release_versions()
         {
@@ -150,12 +154,12 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.PreMajor, DoVcs = true, DryRun = false});
+            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.PreMajor, DoVcs = true, DryRun = false });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -163,7 +167,7 @@ namespace Skarp.Version.Cli.Test
                     ProjectFileProperty.Version
                 ))
                 .MustHaveHappened(Repeated.Exactly.Once);
-            
+
             A.CallTo(() => _filePatcher.Flush(
                     A<string>.That.Matches(path => path == csProjFilePath)))
                 .MustHaveHappened(Repeated.Exactly.Once);
@@ -174,8 +178,8 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _vcsTool.Tag(
                     A<string>.That.Matches(tag => tag == "v2.0.0-next.0")))
                 .MustHaveHappened(Repeated.Exactly.Once);
-        }  
-        
+        }
+
         [Fact]
         public void VersionCli_can_bump_pre_release_with_custom_prefix()
         {
@@ -189,12 +193,13 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.PreMajor, DoVcs = true, DryRun = false, PreReleasePrefix = "beta"});
+            _cli.Execute(new VersionCliArgs
+                { VersionBump = VersionBump.PreMajor, DoVcs = true, DryRun = false, PreReleasePrefix = "beta" });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -202,7 +207,7 @@ namespace Skarp.Version.Cli.Test
                     ProjectFileProperty.Version
                 ))
                 .MustHaveHappened(Repeated.Exactly.Once);
-            
+
             A.CallTo(() => _filePatcher.Flush(
                     csProjFilePath))
                 .MustHaveHappened(Repeated.Exactly.Once);
@@ -213,8 +218,8 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _vcsTool.Tag(
                     "v2.0.0-beta.0"))
                 .MustHaveHappened(Repeated.Exactly.Once);
-        }  
-        
+        }
+
         [Fact]
         public void VersionCli_can_bump_pre_release_with_build_meta_versions()
         {
@@ -228,12 +233,13 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.PreMajor, DoVcs = true, DryRun = false, BuildMeta = "master"});
+            _cli.Execute(new VersionCliArgs
+                { VersionBump = VersionBump.PreMajor, DoVcs = true, DryRun = false, BuildMeta = "master" });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -241,7 +247,7 @@ namespace Skarp.Version.Cli.Test
                     ProjectFileProperty.Version
                 ))
                 .MustHaveHappened(Repeated.Exactly.Once);
-            
+
             A.CallTo(() => _filePatcher.Flush(
                     A<string>.That.Matches(path => path == csProjFilePath)))
                 .MustHaveHappened(Repeated.Exactly.Once);
@@ -253,7 +259,7 @@ namespace Skarp.Version.Cli.Test
                     A<string>.That.Matches(tag => tag == "v2.0.0-next.0+master")))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
-        
+
         [Fact]
         public void VersionCli_can_bump_versions_can_skip_vcs()
         {
@@ -267,12 +273,12 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.Major, DoVcs = false, DryRun = false});
+            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = false, DryRun = false });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -286,7 +292,7 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _vcsTool.Commit(A<string>._, A<string>._)).MustNotHaveHappened();
             A.CallTo(() => _vcsTool.Tag(A<string>._)).MustNotHaveHappened();
         }
-        
+
         [Fact]
         public void VersionCli_can_bump_versions_can_dry_run()
         {
@@ -300,16 +306,17 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            var info = _cli.Execute(new VersionCliArgs{VersionBump = VersionBump.Major, DoVcs = true, DryRun = true});
+            var info = _cli.Execute(new VersionCliArgs
+                { VersionBump = VersionBump.Major, DoVcs = true, DryRun = true });
 
             Assert.NotEqual(info.OldVersion, info.NewVersion);
             Assert.Equal("2.0.0", info.NewVersion);
-            
+
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
                     A<string>.That.Matches(newVer => newVer == "2.0.0"),
@@ -337,12 +344,13 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false, CommitMessage = "commit message" });
+            _cli.Execute(new VersionCliArgs
+                { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false, CommitMessage = "commit message" });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -376,13 +384,17 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageName).Returns("unit-test");
 
             // Act
-            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false, CommitMessage = "bump from v$oldVer to v$newVer at $projName" });
+            _cli.Execute(new VersionCliArgs
+            {
+                VersionBump = VersionBump.Major, DoVcs = true, DryRun = false,
+                CommitMessage = "bump from v$oldVer to v$newVer at $projName"
+            });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -416,12 +428,13 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
 
             // Act
-            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false, VersionControlTag = "vcs tag" });
+            _cli.Execute(new VersionCliArgs
+                { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false, VersionControlTag = "vcs tag" });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -455,13 +468,17 @@ namespace Skarp.Version.Cli.Test
             const string csProjFilePath = "/unit-test/test.csproj";
             A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
 
-            A.CallTo(() => _fileParser.Load(A<string>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
             A.CallTo(() => _fileParser.Version).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageVersion).Returns("1.2.1");
             A.CallTo(() => _fileParser.PackageName).Returns("unit-test");
 
             // Act
-            _cli.Execute(new VersionCliArgs { VersionBump = VersionBump.Major, DoVcs = true, DryRun = false, VersionControlTag = "bump from v$oldVer to v$newVer at $projName" });
+            _cli.Execute(new VersionCliArgs
+            {
+                VersionBump = VersionBump.Major, DoVcs = true, DryRun = false,
+                VersionControlTag = "bump from v$oldVer to v$newVer at $projName"
+            });
 
             // Verify
             A.CallTo(() => _filePatcher.PatchField(
@@ -480,6 +497,67 @@ namespace Skarp.Version.Cli.Test
             A.CallTo(() => _vcsTool.Tag(
                     A<string>.That.Matches(tag => tag == "bump from v1.2.1 to v2.0.0 at unit-test")))
                 .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void VersionCli_can_read_version_from_version_field()
+        {
+            // Configure
+            A.CallTo(() => _vcsTool.IsRepositoryClean()).Returns(true);
+            A.CallTo(() => _vcsTool.IsVcsToolPresent()).Returns(true);
+            A.CallTo(() => _vcsTool.Commit(A<string>._, A<string>._)).DoesNothing();
+            A.CallTo(() => _vcsTool.Tag(A<string>._)).DoesNothing();
+
+            A.CallTo(() => _fileDetector.FindAndLoadCsProj(A<string>._)).Returns("<Project/>");
+            const string csProjFilePath = "/unit-test/test.csproj";
+            A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
+
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Version).Returns("2.0.0");
+            A.CallTo(() => _fileParser.PackageVersion).Returns("1.0.0");
+
+            // Act
+            var output = _cli.Execute(new VersionCliArgs
+            {
+                ProjectFilePropertyName = ProjectFileProperty.Version,
+                VersionBump = VersionBump.None,
+                OutputFormat = OutputFormat.Bare,
+                DoVcs = true,
+                DryRun = false
+            });
+
+            Assert.Equal("2.0.0", output.OldVersion);
+        }
+        
+        [Fact]
+        public void VersionCli_can_read_version_from_package_version_field()
+        {
+            // Configure
+            A.CallTo(() => _vcsTool.IsRepositoryClean()).Returns(true);
+            A.CallTo(() => _vcsTool.IsVcsToolPresent()).Returns(true);
+            A.CallTo(() => _vcsTool.Commit(A<string>._, A<string>._)).DoesNothing();
+            A.CallTo(() => _vcsTool.Tag(A<string>._)).DoesNothing();
+
+            A.CallTo(() => _fileDetector.FindAndLoadCsProj(A<string>._)).Returns("<Project/>");
+            const string csProjFilePath = "/unit-test/test.csproj";
+            A.CallTo(() => _fileDetector.ResolvedCsProjFile).Returns(csProjFilePath);
+
+            A.CallTo(() => _fileParser.Load(A<string>._, A<ProjectFileProperty>._)).DoesNothing();
+            A.CallTo(() => _fileParser.Version).Returns("2.0.0");
+            A.CallTo(() => _fileParser.PackageVersion).Returns("1.0.0");
+            A.CallTo(() => _fileParser.DesiredVersionSource).Returns(ProjectFileProperty.PackageVersion);
+
+            // Act
+            var output = _cli.Execute(new VersionCliArgs
+            {
+                ProjectFilePropertyName = ProjectFileProperty.PackageVersion,
+                VersionBump = VersionBump.None,
+                OutputFormat = OutputFormat.Bare,
+                DoVcs = true,
+                DryRun = false
+            });
+
+            Assert.Equal("1.0.0", output.OldVersion);
         }
     }
 }


### PR DESCRIPTION
This PR addresses multiple issues with the newly added `PackageVersion` field, as reported in #113 and #114.

- The distinction between using `version` and `packageversion` was missing from the `VersionCli.cs` which is responsible for some actions. The usage of the new field has been fixed
- The `ProjectFileParser` was likewise missing proper handling of the new field and thus defaulted to using version / versionprefix
- The `dump version` command was blatantly hardcoded to just dumping `PackageVersion` which is obviously wrong. It should now respect the CLI settings of using either `Version` or `PackageVersion` for dumping. 