### PR TITLE
Create annotated git tags

### DIFF
--- a/src/Vcs/Git/GitVcs.cs
+++ b/src/Vcs/Git/GitVcs.cs
@@ -48,7 +48,7 @@ namespace Skarp.Version.Cli.Vcs.Git
         /// <param name="tagName">Name of the tag</param>
         public void Tag(string tagName)
         {
-            if(!LaunchGitWithArgs($"tag {tagName}"))
+            if(!LaunchGitWithArgs($"tag -a {tagName} -m {tagName}"))
             {
                 throw new OperationCanceledException("Unable to create tag");
             }


### PR DESCRIPTION
I have been working with some CI workflows recently where we use commands like `git describe --abbrev=0`. This only works as intended when using _annotated tags_.

Since we still use this tool, I figured it would make sense to make this change, as it will likely benefit others as well.

I am not sure if this change can disrupt existing CI workflows for some people, though.